### PR TITLE
fix(chat): anchor gemma-4 tool-call grammar with p.end() to stop runaway

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1122,7 +1122,7 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
             auto response_format = p.literal("```json") <<
                 p.content(p.schema(p.json(), "response-format-schema", inputs.json_schema)) <<
                 p.literal("```");
-            return start + p.optional(thought) + response_format;
+            return start + p.optional(thought) + response_format + p.end();
         }
 
         if (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE) {
@@ -1183,12 +1183,21 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
             auto scan_to_toolcall = p.rule("scan-to-toolcall", p.until("<|tool_call>"));
             auto content = p.rule("content", p.content(p.until_one_of({"<|channel>", "<channel|>", "<|tool_call>"})));
             auto message = p.rule("message", thought + content);
-            return start + p.zero_or_more(message) + scan_to_toolcall + tool_call;
+            // Anchor with p.end() so the model is forced to terminate after the tool-call
+            // sequence completes. Without this anchor, the lazy grammar's tool_call repeat
+            // (max = -1 under parallel_tool_calls) accepts arbitrarily-long output, and IQ4
+            // quants in particular can fail to emit <end_of_turn> after <tool_call|>,
+            // producing runaway generation that the client sees as indefinite "executing..."
+            // spinners while tokens keep streaming.
+            return start + p.zero_or_more(message) + scan_to_toolcall + tool_call + p.end();
         }
 
         // Gemma 4 may emit an extra <|channel>thought\n<channel|> at the end of the content. It may
         // also emit a single trailing <channel|> token. Consume all complete reasoning blocks and
         // then stop at the first unmatched <channel|> token.
+        // Note: no p.end() anchor here — this is the parser-only path (no grammar constrains
+        // generation), and trailing unmatched <channel|> tokens are part of gemma-4's normal
+        // output that must be tolerated.
         auto content = p.rule("content", p.content(p.until_one_of({"<|channel>", "<channel|>"})));
         auto message = p.rule("message", thought + content);
         return start + p.one_or_more(message);


### PR DESCRIPTION
## Summary

- Adds `+ p.end()` to the two grammar-constrained gemma-4 paths (tool-calls and response-format) in `common/chat.cpp`.
- Stops runaway generation observed on gemma-4 31B IQ4_XS where the model emits tool calls + reasoning + content + more tool calls indefinitely, surfacing in the webui as indefinite "executing..." spinners on tool cards while the stream keeps flowing.
- Mirrors the pattern every other tool-calling grammar in `chat.cpp` already uses (DeepSeek, GLM-4, Qwen3, etc. all anchor with `p.end()`).

## Why this works

The gemma-4 PEG was the lone tool-calling grammar without an `$`-style end-of-input anchor. Under `parallel_tool_calls=true`, the tool-call `p.repeat(..., max=-1)` accepts arbitrarily-long sequences — so the model is free to emit `<tool_call>...<tool_call|>` indefinitely, never being constrained to terminate. IQ4_XS in particular makes this pathological: the quant degrades the model's tendency to sample `<end_of_turn>` after a closing `<tool_call|>`.

Adding `p.end()` forces the grammar-constrained sampler to terminate the sequence at the structurally correct point (after the optional content + tool_call block).

## Scope

- Tool-call path (line 1186): anchored.
- Response-format path (line 1125): anchored.
- No-tools path (line 1194): intentionally **left unchanged** — that path is parser-only (no grammar constrains generation), and existing tests verify it must tolerate gemma-4's trailing `<channel|>` tokens.

## Test plan

- [x] `./build/bin/test-chat` — all passing
- [x] `./build/bin/test-chat-peg-parser` — 198 assertions, 0 failures
- [x] Local llama-server boot with gemma-4-31B-it-IQ4_XS + `parallel_tool_calls=true` + 2-tool prompt: terminates in ~6s with `finish_reason: tool_calls` and 177 completion tokens (non-stream) / `[DONE]` properly emitted (stream)
- [ ] Validate on titan after merge with the deployed router config

🤖 Generated with [Claude Code](https://claude.com/claude-code)