### PR TITLE
feat(dflash): integrate DFlash block-diffusion speculative decoder (rebased on post-rewrite ht)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,23 @@ occasionally only update one.
 - [README.md](README.md) — full HT Fork Changes inventory
 - [tools/termd/README.md](tools/termd/README.md) — sandbox sidecar HTTP/WS
   reference
+
+## Model capability for AI maintainers
+
+Acting as the standing AI maintainer for this fork — multi-day debug arcs
+(e.g. dflash audit rounds), coordinating multi-agent deploys, judging when
+to act vs surface to the human — requires a model in the **Claude Opus
+capability tier** (or equivalent). Less capable models tend to drift from
+the goal, re-introduce already-disproven hypotheses, miss subtle issues
+(double-applied framework transforms, etc.), and under-surface destructive
+operations that need human approval.
+
+Smaller / cheaper models are fine for **scoped tasks** — one-shot
+implementations from a clearly-specified design, mechanical edits, bench
+harness execution, lint fixes — when handed off by an Opus-class
+maintainer with concrete instructions. They are **not** appropriate for
+the standing maintainer role itself.
+
+If you are running as the AI maintainer here and you are not in this
+tier, surface that and propose a handoff rather than driving cutting-edge
+work autonomously.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,666 @@
+# DFlash Handoff — Gemma 4 31B + DFlash drafter
+
+## Current status (2026-05-24, build with b0a828e8e)
+
+End-to-end DFlash speculative decoding works. **Best acceptance crossed
+double digits** (11.36% Q6_K best, 8.89% mean) after fixing the Gemma4
+embedding-scale + softcap inheritance per vLLM PR #41703. Still
+significantly under the published ~21% MT-Bench / 44% HumanEval acceptance.
+
+| run                                          | gen t/s | accept (mean of 3) | best |
+|---------------------------------------------|--------:|-------------------:|-----:|
+| baseline (`llama-cli`, target alone)        |   29.1  |          —         |   —  |
+| Round-3 (Q4_K_M drafter, pre-fix)            | 14.9   |          4.92%     | -    |
+| Round-5 (Q6_K drafter, pre-fix)              | 10-11  |          6.88%     | 8.51% |
+| **Round-6 (Q6_K, embed-scale+softcap fix)**  | 10-11  |        **8.89%**   | **11.36%** |
+| Round-6 (Q4_K_M, embed-scale+softcap fix)    | 10-11  |          6.76%     | 8.16% |
+
+Reference target for our prompt class (conversational, MT-Bench-like)
+is **~21% acceptance per vLLM PR #41703**. We're at 8.89% mean — gap
+of ~12pp remains. HumanEval-class prompts (code) would target ~44%.
+
+DFlash is still slower than baseline because acceptance rate is below
+the break-even point (block_size=16 means even 1/16 accept is "free
+draft cost amortization"; need ~25% accept for net speedup vs target alone).
+
+## What we ruled out
+
+1. **Arch loading.** `llm_arch_from_string` strips `-draft` suffix, the
+   model-loader passes `arch_name_override` so KV lookups hit
+   `dflash-draft.*` keys.
+2. **Tokenizer mismatch.** Vocab sha256 byte-identical between target and
+   drafter (`7af66a9004b0dd94`), merges sha256 identical
+   (`ea437aa17955e79c`), n_tokens=262144 both, special-token ids match
+   except EOS (target=106 `<end_of_turn>`, drafter=1 `<eos>`) — EOS only
+   matters at stream end, not mid-stream verification.
+3. **Drafter graph.** `src/models/dflash.cpp` builds cross-attention over
+   `inp_dflash->target_hidden`, with `pos_ctx` and `kq_mask` filled in
+   `llm_graph_input_dflash::set_input`. Structure looks correct.
+4. **Feature extraction.** `cb(cur, "dflash_extract_N", il)` hooks in
+   both `src/models/llama.cpp` and `src/models/gemma4.cpp` tag the
+   post-`l_out` hidden state at the layer ids listed in the drafter's
+   `dflash.target_layer_ids = [1, 12, 23, 35, 46, 57]`. All ids are in
+   range for the 60-layer target.
+
+## Updated diagnosis (round 2)
+
+The slice in `common/speculative.cpp:855-860` is actually **correct on
+paper**:
+- After verification, target's `extract_dflash_features` stores K+1
+  features in ubatch order: `[id_last, draft0, draft1, ..., draftK-1]`
+  at positions `[n_past_old, n_past_old+1, ..., n_past_old+K]`.
+- Speculative algorithm always accepts drafts in prefix order: m accepts
+  → first m+1 ubatch positions ARE the committed tokens.
+- Taking `features[0..n_new]` with `n_new = m+1` aligns correctly with
+  the m+1 newly-committed tokens.
+
+So the alignment is right **IF** features and ubatch positions are in
+the same order, which they are in the standard verification flow.
+
+## Structural integration is consistent with the drafter GGUF
+
+Compared our `src/models/dflash.cpp` graph against the `dflash-pr` POC
+branch's older graph. Key insight: **the POC was written for a different
+drafter variant**. POC uses `LLM_TENSOR_FFN_NORM` ("blk.N.ffn_norm");
+our drafter GGUF has `LLM_TENSOR_ATTN_POST_NORM`
+("blk.N.post_attention_norm") and no `ffn_norm`. Our graph uses
+`layer.attn_post_norm` — correct for our GGUF.
+
+POC also has no bucket-rounding/masking; it rebuilds the graph every
+step. We bucket-round + mask padding for graph reuse — masking logic in
+`llm_graph_input_dflash::set_input` looks correct (masks `[n_real,
+ctx_len)`).
+
+## Round-3 bench: extraction point
+
+| run                                | accept |
+|------------------------------------|-------:|
+| Q6_K late (after l_out, default)   | 10.69% |
+| Q6_K early (before per-layer-embd) |  6.22% |
+| Q4_K_M late                        |  4.92% |
+| Q4_K_M early                       |  5.56% |
+
+Late extraction (current default, post-`l_out`) is correct. Toggle via
+`LLAMA_DFLASH_EXTRACT=early` for ablation.
+
+## Round-2 bench results (2026-05-23 ~20:06-20:09 UTC)
+
+| run                                                | accept | gen t/s |
+|----------------------------------------------------|-------:|--------:|
+| Q4_K_M drafter, ctx_window=512 (baseline-dflash)   |  4.92% |  14.95  |
+| Q4_K_M + `LLAMA_GRAPH_REUSE_DISABLE=1`             |  4.92% |  13.85  |
+| Q4_K_M + `LLAMA_DFLASH_CTX_WINDOW=0`               |  6.22% |  14.44  |
+| Q5_K_M drafter                                      |  3.70% |  13.23  |
+| Q6_K drafter (same prompt)                          | 10.69% |  15.78  |
+| Q6_K drafter (different longer prompt)              |  8.01% |  14.47  |
+| Q8_0 drafter                                        |  7.60% |  14.81  |
+| BF16 drafter (ctx=2048, q8_0 KV)                    |  9.42% |  14.30  |
+
+Two conclusions land cleanly:
+
+1. **Graph reuse is innocent.** Same accept rate to 4 sig figs with and
+   without `LLAMA_GRAPH_REUSE_DISABLE=1`. The graph caching mechanism
+   isn't corrupting input tensors across iterations.
+
+2. **Drafter quantization has real but bounded effect.** Q6_K is ~2× Q4_K_M.
+   But the absolute ceiling here is ~10% accept — vs published DFlash
+   30-50%. So the drafter is fundamentally under-conditioned by the
+   target features even at high precision.
+
+Truncation (`ctx_window`) costs a few percent but is not the main bug.
+
+## Round-4: hypothesis 2 (per-layer renorm) — RULED OUT (2026-05-24)
+
+Implemented env-gated experiment in `src/models/dflash.cpp` to apply
+`layer.attn_norm` to `fused_target` before each layer's wk/wv
+(`LLAMA_DFLASH_PER_LAYER_RENORM=1`). Clean 3x3 A/B on Q6_K with VRAM
+free (centurion-llm scaled to 0):
+
+| run | renorm OFF | renorm ON |
+|----:|-----------:|----------:|
+| 1   | 5.56%      | 2.02%     |
+| 2   | 6.22%      | 4.92%     |
+| 3   | 6.22%      | 4.30%     |
+| **mean** | **6.00%** | **3.75%** |
+
+Per-layer renorm makes accept rate **~2.25pp WORSE** on Q6_K. Strong
+signal that the drafter was NOT trained with per-layer ctx renorm —
+current implementation (single `dflash_hidden_norm` at entry,
+following POC design) matches what the drafter expects. The env-gate
+stays in dflash.cpp for future ablation symmetry but defaults off.
+
+**Variance caveat.** Q6_K baseline run-to-run variance is ±2pp on
+same seed/prompt/code. The HANDOFF Round-3 table value of 10.69%
+for Q6_K appears to be an outlier or stale-code state; reproducible
+range under current HEAD (d74f7e1c6) is 4.3-6.2%. Update Round-3
+table accordingly when next bench cycle happens.
+
+## Round-11: post-Gate-C lifecycle fixes (2026-05-27..28)
+
+After Gate C verified on titan (8.14% accept, zero NaN on the smoke
+harness) heierchat tripped on the first real streaming chat request
+and the dflash child died. Investigation surfaced four additional
+issues; this round patched all of them and added a startup-time
+refusal for multi-slot configurations the design doesn't yet support.
+
+| commit     | summary |
+|------------|---------|
+| 770fed433  | extract_dflash_features APPENDs across ubatches (multi-ubatch prefill correctness) |
+| b6b96bbb2  | clear target_features at decode start; drop begin()-clear |
+| fbefb9657  | refuse to start when DFlash + --parallel > 1 |
+| 327f94791  | slot-reuse NaNs, split-prefill segfaults, rollback drift |
+
+### Multi-ubatch prefill overflow (770fed433)
+
+`extract_dflash_features` was calling `target_features.resize(n_embd *
+n_tokens)` once per ubatch, so for any prompt > `n_ubatch` (default
+512) the buffer ended up holding ONLY the last ubatch's features. The
+drafter then read `n_new = n_total - dflash_n_past` features from
+offset 0, overflowing past `target_features.size()` into adjacent heap
+→ SIGSEGV → dflash child exited unreaped → router saw zombie → 500s
+to clients.
+
+Round-9/10 smoke prompts ("Write five short haikus about the ocean")
+were ~35 tokens and fit in a single ubatch, so the buffer happened to
+be sized correctly and the bug never tripped on smoke. Real chat-
+history with a system prompt + a few turns crosses 512 trivially.
+
+Fix: APPEND per ubatch (`resize(prev + new)`). The drafter reads from
+`dflash_n_past * n_target_features` since the buffer holds everything
+since `begin()`. New public API `llama_clear_dflash_target_features`
+for the drafter to reset at request boundaries.
+
+### Lifecycle scope wrong (b6b96bbb2)
+
+The 770fed433 lifecycle had three flaws (reviewer + my own re-read):
+
+- `begin()` clear fires AFTER the prompt-prefill decode, so the very
+  next `draft()` read an empty buffer.
+- `begin()` clear also wipes sibling-slot features sharing `ctx_tgt`.
+- APPEND-with-offset-read drifts post-rollback because `dflash_n_past`
+  stays stale while re-decoded features extend the buffer past the
+  offset the drafter reads from.
+
+Fix: scope `target_features` lifetime to a single decode call —
+APPEND within decode, clear at decode start, `draft()` reads offset 0.
+Bounded memory, no cross-slot stomping, no rollback drift.
+
+### --parallel > 1 unsafe (fbefb9657)
+
+Reviewer flagged that `target_features` is a single flat vector
+shared across slots; under continuous batching with `--parallel > 1`
+slots co-decode in one `llama_decode()` call and their features
+interleave — per-slot `draft()` gets garbage (not OOB as the review
+trace suggested, but wrong-features-in-bounds). The hazard predates
+the Round-11 redesign — it's been latent since day one — but became
+more obvious with the v2 single-decode-scope lifetime.
+
+Fix (Path A from review): fail fast in `load_model()` if dflash +
+`n_parallel > 1` — refuse to start the server. Production preset is
+`--parallel 1`, so nothing in flight is affected. Path B (per-seq_id
+`target_features`) is filed as task #107 for the longer-term multi-
+slot unblock.
+
+### Slot-reuse + split-prefill + rollback (327f94791)
+
+Three more issues caught after the gate landed:
+
+- **Slot-reuse NaNs:** `begin()` didn't mark the draft context as
+  needing a fresh `sched_reserve`, so reused slots could inherit
+  stale graph reservations. Fix: `begin()` calls
+  `llama_set_dflash_need_reserve(ctx_dft_dec)` (new public API).
+- **Split-prefill segfaults:** the v2 clear-at-every-decode-start
+  broke split-prefill (checkpoints or batches > `n_batch`) because
+  each subsequent decode wiped the partially-accumulated prompt
+  features. Fix: only clear `target_features` when the batch
+  contains `pos == 0` (start of a prompt); otherwise accumulate
+  across consecutive prefill decodes. The drafter clears the buffer
+  itself at the end of `draft()` once features are consumed.
+- **Rollback drift:** `draft()` now truncates `accumulated_ctx` and
+  resets `dflash_n_past` when `n < dflash_n_past`, handling
+  partial-accept rollback directly (closes the deferred follow-up
+  flagged at the end of Round-10).
+
+### Status
+
+All four commits are on `origin/feat/dflash-integration`. PR #53
+points at HEAD = 327f94791. Individual verification notes live in
+each commit message; no fresh end-to-end accept-rate bench was run
+in Round-11 — these were correctness restorations on configurations
+that crashed or NaN'd, not perf tuning.
+
+The `--parallel > 1` gate is a hard refusal at startup; if anything
+on titan ever flips `--parallel` higher, server load_model() returns
+false and the dflash drafter does not initialize.
+
+## Round-10: third gate — checkpoint restore (2026-05-27, 44ea35688)
+
+Round-9 gates A+B passed local but titan continued failing on the same
+chat-completions smoke (0/873 accept, NaN signature intact) even after
+the .so was confirmed loaded with both gates. After elimination — Gate B
+was correctly skipping the per-slot reuse branch on titan because
+heierchat already sets `cache_prompt: false` client-side, so Gate B
+never *had* to fire there. Some OTHER cache mechanism was firing.
+
+**Third path:** server-context.cpp:2756 — context-checkpoint restore.
+
+When `pos_min >= pos_min_thold` (SWA-driven), the slot prefill flow
+searches `slot.prompt.checkpoints` for a usable checkpoint and, if
+found, calls `it->load_tgt(ctx_tgt, ...)`. Same bug class as A+B:
+target KV gets restored for cached positions but dflash target
+features for those positions are NOT re-extracted; the drafter's
+subsequent read overflows the buffer.
+
+Why local probes missed it: with `--parallel >= 4` requests spread
+across slots and checkpoints stay small per slot, so the path rarely
+triggers. Titan ran `--parallel 1`, so a single slot accumulated
+checkpoints across consecutive identical-prompt smoke runs — every
+iteration past the first hit the restore path.
+
+**Fix (44ea35688) — Gate C:** force `do_reset = true` at the
+checkpoint-restore site whenever `params_base.speculative.dflash`,
+making the slot full-re-prefill instead of restoring KV.
+
+**Iteration loop:** built locally on centurion (Arch glibc 2.38) →
+snoop's `kubectl cp` blew up on glibc mismatch with the pod's
+Ubuntu 22.04 (glibc 2.35). Set up `nvidia/cuda:12.4.1-devel-ubuntu22.04`
+build container on centurion (`ht-llama-build`); subsequent rebuilds
+take ~30s incrementally. Hot-patch loop = build .so in container →
+`kubectl cp` to `/app/libllama-server-impl.so` → `pkill -f` the dflash
+child → router auto-respawns child mmap'ing the fresh .so.
+
+Co-investigators: big-dog (third-path hypothesis from the audit of all
+load_tgt/load_dft sites + the `--parallel 1 vs 4` mechanism call);
+snoop-kube (build-container setup, hot-patch flow, smoke verification);
+heierchat (client-side `cache_prompt:false` defensive workaround that
+isolated the Gate-C path by eliminating Gate-B's contribution).
+
+**Verified on titan with default `cache_prompt:true` (no client workaround):**
+  baseline (pre-Gate-C):    0/873 accept   — NaN signature
+  with Gate C (44ea35688):  96/1179 (8.14%) — zero NaN, 5/5 PASS
+
+**Latent follow-up (deferred):**
+  Spec-decode partial-accept rollback path at server-context.cpp:3352
+  (the `n_rollback > 0 && use_ckpt_tgt` branch) restores KV without
+  resetting `dflash_n_past`. In practice the rollback shrinks the
+  prompt so subsequent `draft()` calls see `n_new < 1` and skip
+  (early-exit at common/speculative.cpp:852), not OOB. Worth fixing
+  cleanly by making `common_speculative_impl_dflash::accept()` trim
+  `accumulated_ctx` and adjust `dflash_n_past` on rollback, but the
+  current behavior is correctness-safe, just suboptimal.
+
+**Ops note:** the running pod is hot-patched, not baked. Next image
+build off this commit should be tagged + rolled normally so the .so
+is durable across pod restarts.
+
+## Round-9: prompt-cache + DFlash NaN bug (2026-05-27, d7a88fdbc)
+
+Hit a production regression: dflash on titan emitted all-NaN drafter
+logits on `/v1/chat/completions`, looked like "1 token then stops" in
+heierchat (Markus's screenshot). Root-caused after a long hunt with
+snoop-kube + heierchat.
+
+**Symptom shape:**
+  - `/v1/completions`: 6.94% accept, clean logits
+  - `/v1/chat/completions`: 0% accept, all-NaN drafter logits at every position
+  - drafter argmaxes to `<pad>` (token 0) every time
+  - target generates real tokens, dflash adds zero value but doesn't crash
+
+**Root cause:**
+  Slot prompt cache (server-context.cpp prompt_load) restores target KV
+  state via `llama_state_seq_set_data_ext` for cached prefix tokens but
+  does NOT re-extract DFlash target features for those positions. Only
+  NEW tokens decoded after cache hit get their features extracted.
+
+  Then `common_speculative_impl_dflash::draft()` (common/speculative.cpp:857)
+  reads `n_new = n - dflash_n_past` features, where `n_new` counts ALL
+  prompt tokens (cached + new). The read overflows the
+  `dflash.target_features` buffer past its actual size (only NEW token
+  count) → OOB read → garbage values → drafter consumes them as
+  "target features" via fc + hidden_norm + per-layer K_ctx → NaN logits
+  → argmax(<NaN, NaN, ...>) = token 0 (<pad>) → target rejects every
+  draft → 0% accept.
+
+  Affected every chat completion after the first for any given slot.
+  `/v1/completions` had the same vulnerability — just happened to land
+  on a fresh slot in early probes by luck.
+
+**Fix shipped — TWO gates (Round-9, d7a88fdbc + 65f46f0f8):**
+  llama-server has TWO independent cache mechanisms that both let the
+  target skip decoding cached prefix tokens. Both have to be gated for
+  dflash to work correctly.
+
+  Gate A (d7a88fdbc) — at slot allocation, disables the GLOBAL
+  `server_prompt_cache` load path when `params_base.speculative.dflash`
+  is true:
+    update_cache = false  // skip global prompt cache when dflash active
+
+  Gate B (65f46f0f8) — at slot prefill, disables the per-slot prompt
+  prefix reuse driven by `slot.task->params.cache_prompt`:
+    if (slot.task->params.cache_prompt && !dflash_active) { /* reuse */ }
+
+  Either alone is insufficient. d7a88fdbc shipped first; titan smoke
+  still failed with identical-prompt requests because Gate B (the
+  per-slot path) wasn't gated. Different-prompt requests partially worked
+  (small common prefix → small OOB). Both gates together cover both
+  request patterns.
+
+  Tradeoff: first-request prompt-eval cost is paid every request; spec
+  gains still net win on any non-trivial generation.
+
+**Local verification (titan-matched: --parallel 1, --jinja, --cont-batching):**
+  5 sequential IDENTICAL prompts (matches snoop's smoke pattern):
+    Pre-both-gates:                0/0/0/0/0% NaN cascade
+    Gate A only (d7a88fdbc):       0/0/0/0/0% NaN (Gate B path still wins)
+    Both gates (65f46f0f8):        7.36/9.35/9.24/8.84/6.90% accept, **zero NaN**
+
+**Field workaround (still works without rebuild):**
+  Set `cache_prompt: false` in the request body.
+
+**Proper fix (deferred — Round-10 candidate):**
+  Two architectural paths to recover prompt cache benefit while keeping
+  dflash correct:
+
+  (a) Re-extract features for the cached prefix on slot restore. Pseudo:
+      after `prompt_load`, run a single full-prefix forward through the
+      target to populate `dflash.target_features`. Adds back the prompt-
+      eval cost we just dropped, but exact KV cache stays intact.
+
+  (b) Cache the DFlash target features alongside the KV cache snapshot.
+      Extend `server_prompt_cache::states[].data` to carry the
+      per-position dflash feature vectors. On restore, write features
+      back into ctx_tgt's `dflash.target_features`. Memory-heavier
+      (~32 KB/token at n_target_features=32256 floats * 4 bytes — wait,
+      that's 130 KB/token; for a 4096-ctx prompt cache this is ~530 MB,
+      noticeable but cap-able). Preserves the prompt-cache perf win
+      end-to-end. Cleanest fix.
+
+  Pick (a) for low-risk; (b) for the long term.
+
+**Co-investigators:** snoop-kube (titan log mining, side-by-side
+A/B between `/v1/completions` vs `/v1/chat/completions`); heierchat
+(client-side stream-shape debugging that ruled out UI bug); big-dog
+(coordination); aioc (hint that framing tokens were downstream of
+prompt structure, not independent).
+
+## Round-8: shipped to titan (2026-05-27, unified-llm:dflash-794ddb2df)
+
+`feat/dflash-integration` tip (with surgical `--remap-developer-role` port
+required by titan-llm's entrypoint) baked into `unified-llm:dflash-794ddb2df`
+by snoop-kube, deployed on titan-llm. Preset `gemma-4-31b-dflash-Q6_K` live
+on `http://192.168.8.158:30184`. End-to-end smoke green via
+`scripts/smoke-dflash-deployed.sh`.
+
+Live accept rate on titan: **4.48%** on a single 256-token code prompt
+(670 drafted, 30 accepted). Below centurion bench mean of **8.89%** on Q6_K.
+
+Snoop's three hypotheses for the delta (deferred — not user-blocking):
+1. Target Q4_K_M numerical difference titan vs centurion (low likelihood, same model file).
+2. ctx-size=4096 in preset clipping draft proposals on longer rolling contexts.
+3. Titan's 2×3090 tensor-split splitting a draft layer awkwardly across cards
+   (even with `n-gpu-layers-draft=99` — worth pinning `--tensor-split` to
+   single-card for the drafter as an A/B).
+
+DFlash is functional in production. Net throughput is below break-even
+(target alone ~29 t/s on centurion; with dflash at 4.48% accept the speedup
+is < 1.0×) but heierchat picker UX works, route resolves cleanly, drafter
+loads alongside target.
+
+## Round-7: GGUF tensor-inventory parity vs safetensors (2026-05-24)
+
+Compared `models/dflash-gemma4-31b/model.safetensors` against the
+Anbeeld GGUF tensor list via `gguf-dump` + `safetensors.safe_open`.
+
+| | safetensors | GGUF (Q6_K) | match |
+|---|---:|---:|---|
+| Total tensors | 58 | 58 | ✓ |
+| fc.weight | (5376, 32256) bf16 | dflash_fc.weight (32256, 5376) Q6_K | ✓ shape (transposed for GGUF row layout) |
+| hidden_norm.weight | (5376,) bf16 | dflash_hidden_norm.weight (5376,) F32 | ✓ |
+| 5 × layers.N.{input,post_attention}_layernorm | (5376,) | blk.N.{attn_norm,post_attention_norm} (5376,) F32 | ✓ all 5 layers |
+| 5 × layers.N.self_attn.{q,k,v,o}_proj | dims match per head config | blk.N.{attn_q,attn_k,attn_v,attn_output} | ✓ all 5 layers |
+| 5 × layers.N.self_attn.{q,k}_norm | (128,) per-head-dim | blk.N.{attn_q_norm,attn_k_norm} | ✓ all 5 layers |
+| 5 × layers.N.mlp.{down,gate,up}_proj | dims match intermediate=10752 | blk.N.{ffn_down,ffn_gate,ffn_up} | ✓ all 5 layers |
+| norm.weight | (5376,) | output_norm.weight (5376,) F32 | ✓ |
+| tok_embd / lm_head | n/a (tied/shared) | none in drafter, bound to target at runtime | ✓ |
+
+**Hypothesis 1 (GGUF conversion fidelity at the inventory level) is
+RULED OUT.** Every safetensors tensor maps cleanly to a same-shape
+GGUF entry. Conversion didn't drop, rename, or mis-shape anything.
+
+**Round-7b: per-tensor numerical comparison** (`scripts/compare-dflash-weights.py`):
+
+Loaded bf16 safetensors via raw byte → uint16 → fp32 reinterpret cast,
+dequantized GGUF Q6_K via `gguf.quants.dequantize`, compared per-tensor.
+
+| group | count | mean rel RMS error |
+|---|---:|---:|
+| F32 norm tensors | 22 | **0.000%** (exact) |
+| Q6_K projection tensors | 36 | **1.78%** |
+
+Worst tensor: `fc.weight` (Q6_K) at 2.155% relative RMS error — normal
+for Q6_K quantization. No outlier tensor indicating conversion bug.
+
+**Hypothesis 1 is FULLY ruled out** at both inventory AND numerical
+fidelity levels. The Anbeeld GGUF Q6_K is a clean quantization of the
+z-lab safetensors bf16. Any remaining accept-rate gap is NOT from
+conversion bugs.
+
+Q6_K's ~2% per-tensor error compounds through 5 drafter layers
+(weight × act, then attention softmax, then weight × act, etc.).
+Could plausibly account for several percentage points of accept-rate
+degradation vs bf16. Confirming this requires a BF16 drafter bench
+(currently OOMs at ctx=4096; needs ctx ≤ 2048 + VRAM coordination).
+
+## Round-6: Gemma4 embedding-scale + softcap fix (2026-05-24, b0a828e8e)
+
+Root-cause find from vLLM PR #41703: drafter shares target's tok_embd
++ lm_head. For Gemma4 targets, the drafter must inherit two transforms
+that target applies around the shared weights:
+
+1. **`sqrt(n_embd)` noise embedding normalization** (Gemma4 pipeline).
+   Without it, noise embeddings are ~73× too small.
+2. **`final_logit_softcapping = 30.0`** on drafter's lm_head output.
+   Monotonic; doesn't affect greedy argmax but matches training distribution.
+
+Implementation: `llama-context.cpp:380-395` cross-binding inherits these
+from `target_model->arch == LLM_ARCH_GEMMA4`. `dflash.cpp` consumes via
+`hparams.f_embedding_scale` (applied automatically by `build_inp_embd`'s
+Granite-arch code path — see footgun note below) and a manual softcap
+block matching `gemma4.cpp:443-447`.
+
+**Footgun for future arch ports:** `llama-graph.cpp:1827-1829`
+auto-applies `hparams.f_embedding_scale` inside `build_inp_embd` (originally
+added for Granite). If you also add a manual `ggml_scale(inpL, scale)`
+in your model graph, you get DOUBLE scaling and a quietly broken model.
+Grep for `f_embedding_scale` usages before adding new manual scales.
+First attempt of this fix did double-scale and tanked Q6_K to 2.65%
+mean. Removing manual scale fixed it.
+
+Bench result (Q6_K drafter, 3 runs, q8_0 KV, same prompt/seed):
+
+| pre-fix | with fix |
+|--------:|---------:|
+| 8.51%   | 6.80%    |
+| 7.64%   | 11.36%   |
+| 4.49%   | 8.51%    |
+| **mean 6.88%** | **mean 8.89%** |
+
++2pp lift, first clean cross of 10% threshold. Confirms hypothesis but
+doesn't close the gap to vLLM's ~21% MT-Bench reference.
+
+## Round-5: correctness audit vs upstream PR #22105 + z-lab reference (2026-05-24)
+
+Stopped chasing single-knob hypotheses on the bench and ran a full
+implementation audit against authoritative sources (upstream PR
+ggml-org/llama.cpp#22105, z-lab/dflash PyTorch reference, vLLM
+qwen3_dflash, drafter GGUF metadata dump). Audit summary:
+
+### What matches the reference cleanly
+
+| Item | Reference | Ours | Status |
+|------|-----------|------|--------|
+| `fc` + `dflash_hidden_norm` location | Once outside layer loop | Once at dflash.cpp:72-74 | ✓ |
+| No per-layer renorm of `fused_target` | Confirmed Round-4 | Default off | ✓ |
+| K/V concat order | `[ctx, noise]` | `[ctx, noise]` (dim 2) | ✓ |
+| K/V projection shares same `wk`/`wv` for ctx + noise | Yes | Yes | ✓ |
+| `attn_norm` applied to noise only | Yes | Yes | ✓ |
+| `attn_q_norm` on Q post-reshape | Yes | dflash.cpp:89 | ✓ |
+| `attn_k_norm` on K post-reshape | Yes (post-concat) | Per-side pre-concat (mathematically equivalent for per-token RMSNorm) | ✓ |
+| V not normed, not RoPE'd | Confirmed | dflash.cpp:118-128 | ✓ |
+| Block content `[id_last, MASK×(K-1)]` | Confirmed | speculative.cpp:892-895 | ✓ |
+| Drafts sampled from positions `[1..K-1]` | Confirmed | speculative.cpp:908 | ✓ |
+| `attn_post_norm` as FFN-input norm | Gemma-specific (drafter tensor list) | dflash.cpp:148 | ✓ |
+| FFN type SwiGLU | Confirmed | `LLM_FFN_SILU + PAR` | ✓ |
+| lm_head shared with target | Confirmed | llama-context.cpp:377 binds `model.output` to target's | ✓ |
+| `tok_embd` shared with target | Confirmed | llama-context.cpp:376 binds | ✓ |
+| Non-causal attention | Drafter GGUF has `attention.causal = False` | Our `kq_mask` only masks bucket padding | ✓ |
+| mask_token_id | Drafter GGUF: `4` (matches tokenizer `<mask>` at id 4) | Loaded from KV | ✓ |
+| block_size | 16 (drafter KV) | Loaded from KV | ✓ |
+
+### Divergences identified
+
+1. ~~**Sliding-window attention not implemented in drafter graph.**~~
+   **FIXED in 4b10869a7** (2026-05-24). load_arch_hparams now reads
+   `attention.sliding_window` and `attention.sliding_window_pattern`
+   into hparams.n_swa + hparams.swa_layers. Decoder graph allocates
+   a second `kq_mask_swa` with per-(q_pos,k_pos) windowing; layer
+   loop routes SWA layers through it. Bench-neutral at ctx<=2048
+   (window matches full attention numerically) as expected.
+
+2. **Position scheme is RoPE-relative-only (acknowledged shortcut).**
+   Reference PyTorch uses absolute target-sequence positions
+   monotonically across iterations. We use `[0..n_ctx_used-1]` for
+   ctx and `[n_ctx_used..n_ctx_used+15]` for noise — local positions
+   reset each step. Equivalent under RoPE-relative attention. Upstream
+   PR comment explicitly calls this out as "no draft KV cache" mode.
+
+3. **Extraction point convention.** Tested in Round-5 below — not
+   the bug.
+
+### Round-5 bench: extraction-point ablation, 3x3, q8_0 KV
+
+Added `LLAMA_DFLASH_EXTRACT=upstream` mode in `gemma4.cpp` that tags
+`inpL` at layer start (matches upstream PR #22105's convention where
+the converter applies `+1` to layer ids). A/B vs current default:
+
+| run | mode=late (current) | mode=upstream (PR convention) |
+|----:|--------------------:|------------------------------:|
+| 1   | 8.51%               | 4.49%                          |
+| 2   | 7.64%               | 7.64%                          |
+| 3   | 4.49%               | 5.23%                          |
+| **mean** | **6.88%**     | **5.79%**                      |
+
+Means overlap within one standard deviation. Exact counts repeat
+across modes (11/144 in late_2 and upstream_2; 7/156 in late_3 and
+upstream_1) — there are ~3 distinct "states" the bench lands in and
+extraction-point is not the decision boundary. Late wins by a hair
+which weakly suggests Anbeeld's Gemma converter did NOT apply the
+`+1` shift (i.e. GGUF `target_layer_ids` are raw Python indices).
+
+### Conclusion of audit
+
+Implementation is mostly correct on every architectural detail we
+can verify. The 4-8% accept ceiling vs published 30-50% is not
+explainable by any single structural bug at the llama.cpp level.
+
+Remaining real candidates (in rough order of plausibility):
+
+- **GGUF conversion fidelity vs Anbeeld safetensors.** Compare
+  drafter logits between Anbeeld GGUF and the original z-lab
+  safetensors → CPU fp32 reference on identical inputs. If the
+  GGUF is malformed (missing tensor, wrong shape, miscalibrated
+  scale), this is the most likely culprit. Requires ~6 GB HF
+  download + reference Python inference. **Highest priority.**
+- **Run-to-run variance (CUDA non-determinism).** ±2-3pp variance
+  on same seed/prompt is real. Likely from float reduction order
+  in CUDA flash-attention near tie-break thresholds in greedy
+  sampling, possibly amplified by bidirectional attention. Not a
+  correctness bug per se but pollutes all bench signal. Mitigation:
+  bench at temp>0 with many samples, or move to CPU backend for
+  determinism testing.
+- **SWA implementation gap.** Add SWA-2048 mask to first 4 drafter
+  layers. Low-priority at current ctx sizes but correctness fix.
+
+### Concrete next experiments (revised priority order)
+
+1. **GGUF↔safetensors drafter logit parity.** Download Anbeeld's
+   z-lab/gemma-4-31B-it-DFlash safetensors. Run reference PyTorch
+   forward (single layer at a time if needed) on a fixed input,
+   compare logits to our drafter's logits on the same input. If they
+   diverge beyond ~1% relative error per-position, the GGUF
+   conversion is the bug. Largest single workpiece (~6 GB download +
+   reference inference setup), highest-confidence root-cause signal.
+
+2. **Reduce variance by averaging.** Run 10x same-seed bench at temp 0
+   AND 10x at temp 0.7 with different seeds. Report mean ± std for
+   each mode. Without variance reduction, sub-2pp deltas are noise.
+
+3. **Add SWA mask for blk.0..blk.3 of drafter.** Drafter GGUF
+   has `sliding_window=2048` + pattern `[T,T,T,T,F]`. Currently no
+   SWA enforcement. Add windowing to `llm_graph_input_dflash::set_input`
+   for layers where `is_swa(il)`. Correctness fix; likely
+   bench-neutral at `ctx_window=512` but principled.
+
+4. **Disable graph reuse via env**: `LLAMA_GRAPH_REUSE_DISABLE=1`.
+   Already tested 2026-05-23 — identical accept (4.92%) with and
+   without. Innocent. Re-run only if other variables move.
+
+5. **Try IQ4_XS target** (`gemma-4-31B-it-IQ4_XS.gguf`): if the drafter
+   was trained on hidden states extracted from a different target
+   quant, swapping target quant could realign. Untested.
+
+6. **Warmup interference**: the drafter ctx warmup runs the dflash graph
+   with `cross.v_embd.empty()` → `ctx_len = n_ctx = 4096`. The first
+   real call should reset via `sched_need_reserve` when bucket changes
+   from 0 → small bucket. Verify by adding a log to `sched_reserve` to
+   see if it's actually triggered between warmup and first real draft.
+
+## What works
+
+- Arch registration (`LLM_ARCH_DFLASH`) and KV namespace handling
+- Drafter GGUF loads with arch `dflash-draft`
+- Target hooks (`gemma4.cpp`, `llama.cpp`) fire on the right layers
+- `llama-server` `/v1/chat/completions` `--dflash` plumbing
+- 8 unit tests pass (`./build-dflash/bin/test-dflash`)
+- New: `model: "any"` resolves to the most-recently-used resident model
+  on the router (`server-models.cpp` — `pick_any_resident()`)
+
+## Reproduce the bench
+
+VRAM-clear required (~21 GB on this box was held by the centurion-llm
+qwen pod; snoop-kube scales it down on request).
+
+```bash
+# Baseline
+./build-cuda/bin/llama-cli \
+  -m models/gemma-4-31B-it-Q4_K_M.gguf \
+  -p "Write a 50-word paragraph about speculative decoding." \
+  -n 128 -ngl 99 -fa on -no-cnv --single-turn --perf --temp 0 --seed 1
+
+# DFlash
+./build-cuda/bin/llama-speculative-simple \
+  -m models/gemma-4-31B-it-Q4_K_M.gguf \
+  -md models/dflash-gemma4-31b-gguf/gemma4-31b-it-dflash-Q4_K_M.gguf \
+  --dflash \
+  -p "Write a 50-word paragraph about speculative decoding." \
+  -n 128 -c 4096 -ngl 99 -ngld 99 -fa on --temp 0 --seed 1
+```
+
+## Build
+
+```bash
+cd /home/me/ht/forks/ht-llama.cpp
+cmake --build build-cuda --target llama-cli llama-speculative-simple llama-server -j8
+```
+
+`build-cuda` and `build-dflash` are both CUDA-enabled
+(`GGML_CUDA=ON`); old note that build-dflash was CPU-only was wrong.
+
+## Reference
+
+- Drafter HF: `Anbeeld/gemma-4-31B-it-DFlash-GGUF`
+- DFlash author repo: `z-lab/gemma-4-31B-it-DFlash`
+- Upstream PR: https://github.com/ggml-org/llama.cpp/pull/22105
+- `dflash-pr` local branch holds the older POC for comparison
+- Snoop-kube's offer: titan CUDA1 (~24 GB free, no scale-down needed) —
+  Job manifest pending

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3657,6 +3657,17 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.speculative.types.insert(params.speculative.types.end(), types.begin(), types.end());
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_TYPE"));
+
+    add_opt(common_arg(
+        {"--dflash"},
+        "use DFlash speculative decoding with the draft model",
+        [](common_params & params) {
+            params.speculative.dflash = true;
+            if (std::find(params.speculative.types.begin(), params.speculative.types.end(), COMMON_SPECULATIVE_TYPE_DFLASH) == params.speculative.types.end()) {
+                params.speculative.types.push_back(COMMON_SPECULATIVE_TYPE_DFLASH);
+            }
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_DFLASH"));
     add_opt(common_arg(
         {"--spec-ngram-mod-n-min"}, "N",
         string_format("minimum number of ngram tokens to use for ngram-based speculative decoding (default: %d)", params.speculative.ngram_mod.n_min),

--- a/common/common.h
+++ b/common/common.h
@@ -161,6 +161,7 @@ enum common_speculative_type {
     COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE,  // standalone draft model speculative decoding
     COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3,  // Eagle3 speculative decoding
     COMMON_SPECULATIVE_TYPE_DRAFT_MTP,     // Multi-token prediction
+    COMMON_SPECULATIVE_TYPE_DFLASH,        // DFlash speculative decoding
     COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE,  // simple self-speculative decoding based on n-grams
     COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K,   // self-speculative decoding with n-gram keys only
     COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V, // self-speculative decoding with n-gram keys and 4 m-gram values
@@ -356,6 +357,8 @@ struct common_params_speculative {
     common_params_speculative_ngram_map ngram_map_k4v;
 
     common_params_speculative_ngram_cache ngram_cache;
+
+    bool dflash = false; // use DFlash speculative decoding
 
     bool has_dft() const {
         return !draft.mparams.path.empty() || !draft.mparams.hf_repo.empty();
@@ -606,7 +609,7 @@ struct common_params {
     std::string api_prefix    = "";                                                                         // NOLINT
     std::string chat_template = "";                                                                         // NOLINT
     bool use_jinja = true;                                                                                  // NOLINT
-    bool remap_developer_role = false; // remap "developer" role to "system" for template compatibility
+    bool remap_developer_role = false; // remap "developer" role to "system" for templates that reject unknown roles
     bool enable_chat_template = true;
     bool force_pure_content_parser = false;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -25,6 +25,7 @@ const std::map<std::string, common_speculative_type> common_speculative_type_fro
     {"draft-simple",  COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE},
     {"draft-eagle3",  COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3},
     {"draft-mtp",     COMMON_SPECULATIVE_TYPE_DRAFT_MTP},
+    {"dflash",       COMMON_SPECULATIVE_TYPE_DFLASH},
     {"ngram-simple",  COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE},
     {"ngram-map-k",   COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K},
     {"ngram-map-k4v", COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V},
@@ -777,6 +778,208 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     }
 };
 
+// ========================================================================
+// DFlash speculative decoding
+// ========================================================================
+
+struct common_speculative_impl_dflash : public common_speculative_impl {
+    common_params_speculative_draft params;
+
+    llama_context * ctx_tgt;
+    llama_context * ctx_dft_dec = nullptr;
+
+    llama_batch batch;
+
+    int32_t n_target_features = 0;
+
+    int32_t dflash_n_past = 0;
+
+    std::vector<float> accumulated_ctx;
+
+    common_sampler_ptr smpl;
+
+    common_speculative_impl_dflash(const common_params_speculative & params, uint32_t n_seq,
+            llama_context * ctx_tgt)
+        : common_speculative_impl(COMMON_SPECULATIVE_TYPE_DFLASH, n_seq)
+        , params(params.draft)
+        , ctx_tgt(ctx_tgt)
+    {
+        ctx_dft_dec = this->params.ctx_dft;
+
+        const int32_t n_target_layer_ids = llama_model_dflash_n_target_layers(llama_get_model(ctx_dft_dec));
+        n_target_features = llama_model_n_embd(llama_get_model(ctx_tgt)) * n_target_layer_ids;
+
+        const int32_t model_block_size = llama_model_dflash_block_size(llama_get_model(ctx_dft_dec));
+        batch = llama_batch_init(model_block_size, 0, 1);
+
+        common_params_sampling sparams;
+        sparams.no_perf = false;
+        sparams.top_k = 1;
+        sparams.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
+        smpl.reset(common_sampler_init(llama_get_model(ctx_dft_dec), sparams));
+    }
+
+    ~common_speculative_impl_dflash() override {
+        llama_batch_free(batch);
+    }
+
+    bool need_embd() const override { return false; }
+
+    void begin(llama_seq_id /*seq_id*/, const llama_tokens & /*prompt*/) override {
+        dflash_n_past = 0;
+        accumulated_ctx.clear();
+        // Note: target_features is owned by ctx_tgt and reset at the start of
+        // each llama_decode() (see extract_dflash_features). We deliberately
+        // do NOT clear it here because begin() fires AFTER the prompt-prefill
+        // decode has already extracted the prompt features that the first
+        // draft() call is about to consume.
+        llama_set_dflash_need_reserve(ctx_dft_dec);
+    }
+
+    bool process(const llama_batch & /*batch*/) override {
+        return true;
+    }
+
+    void draft(common_speculative_draft_params_vec & dparams) override {
+        const int model_block_size = llama_model_dflash_block_size(llama_get_model(ctx_dft_dec));
+        const int block_size = model_block_size;
+        const int n_draft = std::min(model_block_size - 1, (int)params.n_max);
+
+        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+            auto & dp = dparams[seq_id];
+            if (!dp.drafting) {
+                continue;
+            }
+
+            auto & result = *dp.result;
+            int n = (int)dp.prompt->size();
+            if (n < dflash_n_past) {
+                accumulated_ctx.resize((size_t)n * (size_t)n_target_features);
+                dflash_n_past = n;
+            }
+            const int n_new = n - dflash_n_past;
+
+            if (n_new < 1) {
+                continue;
+            }
+            // Step 1: append raw target features for newly committed tokens.  The
+            // DFlash graph performs the trained dflash_fc fusion internally.
+            //
+            // The target's target_features buffer is cleared at the start of
+            // every llama_decode() call (see extract_dflash_features). So
+            // immediately after the target's most recent decode, the buffer
+            // holds exactly the features for the tokens decoded in that call,
+            // in order — which is precisely the slice this draft() needs.
+            // The first draft() after prompt prefill consumes prompt features
+            // (T_0); subsequent draft()s after spec-verify decodes consume
+            // the first n_new positions (sampled + accepted drafts).
+            const float * features = llama_get_dflash_target_features(ctx_tgt);
+            const size_t new_size = (size_t)n_target_features * (size_t)n_new;
+            accumulated_ctx.insert(accumulated_ctx.end(), features, features + new_size);
+
+            // Diagnostics for accept-rate debugging — first 5 floats of the newly
+            // appended features + dflash_n_past advancement. Only fires when
+            // LLAMA_DFLASH_DEBUG env var is set, so production runs stay quiet.
+            static const bool dflash_debug = []() {
+                const char * e = std::getenv("LLAMA_DFLASH_DEBUG");
+                return e && e[0] != '\0' && e[0] != '0';
+            }();
+            if (dflash_debug) {
+                LOG_INF("dflash feat debug: n_new=%d n=%d dflash_n_past_old=%d "
+                        "first5=[%.4f %.4f %.4f %.4f %.4f]\n",
+                        n_new, n, dflash_n_past,
+                        features[0], features[1], features[2], features[3], features[4]);
+            }
+
+            const int n_ctx_total = (int)(accumulated_ctx.size() / (size_t)n_target_features);
+            // Set LLAMA_DFLASH_CTX_WINDOW=0 to disable truncation (use full accumulated ctx).
+            static const int ctx_window = []() {
+                const char * e = std::getenv("LLAMA_DFLASH_CTX_WINDOW");
+                return e ? std::atoi(e) : 512;
+            }();
+            const int n_ctx_used = ctx_window > 0 ? std::min(n_ctx_total, ctx_window) : n_ctx_total;
+            const float * ctx_data = accumulated_ctx.data() + (size_t)(n_ctx_total - n_ctx_used) * (size_t)n_target_features;
+
+            llama_set_dflash_accumulated_target_ctx(ctx_dft_dec, ctx_data, n_target_features, n_ctx_used);
+
+            // Step 2: Decode noise block
+            const llama_token mask_token_id = llama_model_dflash_mask_token_id(llama_get_model(ctx_dft_dec));
+
+            llama_memory_clear(llama_get_memory(ctx_dft_dec), false);
+
+            common_batch_clear(batch);
+            for (int i = 0; i < block_size; i++) {
+                const llama_token tok = (i == 0) ? dp.id_last : mask_token_id;
+                common_batch_add(batch, tok, (int32_t)n_ctx_used + i, { 0 }, true);
+            }
+
+            if (llama_decode(ctx_dft_dec, batch) != 0) {
+                LOG_ERR("DFlash: noise decode failed\n");
+                return;
+            }
+
+            dflash_n_past = n;
+
+            // Step 3: Sample draft tokens from positions 1..block_size-1
+            common_sampler_reset(smpl.get());
+
+            const int n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(llama_get_model(ctx_dft_dec)));
+            for (int i = 1; i < block_size && (int) result.size() < n_draft; i++) {
+                const float * logits = llama_get_logits_ith(ctx_dft_dec, i);
+                if (!logits) {
+                    break;
+                }
+
+                const llama_token id = (llama_token)(std::max_element(logits, logits + n_vocab) - logits);
+
+                if (i == 1) {
+                    std::vector<int> top;
+                    top.reserve(5);
+                    for (int j = 0; j < n_vocab; ++j) {
+                        if ((int) top.size() < 5) {
+                            top.push_back(j);
+                            std::sort(top.begin(), top.end(), [&](int a, int b) { return logits[a] > logits[b]; });
+                        } else if (logits[j] > logits[top.back()]) {
+                            top.back() = j;
+                            std::sort(top.begin(), top.end(), [&](int a, int b) { return logits[a] > logits[b]; });
+                        }
+                    }
+                    std::string top_dbg;
+                    for (int tid : top) {
+                        top_dbg += " ";
+                        top_dbg += std::to_string(tid);
+                        top_dbg += "=";
+                        top_dbg += common_token_to_piece(ctx_dft_dec, tid);
+                        top_dbg += ":";
+                        top_dbg += std::to_string(logits[tid]);
+                    }
+                    LOG_INF("dflash logits debug: ctx=%d%s\n", n_ctx_used, top_dbg.c_str());
+                }
+
+                common_sampler_accept(smpl.get(), id, true);
+                result.push_back(id);
+            }
+
+            if (!result.empty()) {
+                std::string dbg;
+                const int n_dbg = std::min<int>(3, result.size());
+                for (int i = 0; i < n_dbg; ++i) {
+                    dbg += " ";
+                    dbg += std::to_string(result[i]);
+                    dbg += "=";
+                    dbg += common_token_to_piece(ctx_dft_dec, result[i]);
+                }
+                LOG_INF("dflash draft debug: ctx=%d block=%d draft:%s\n", n_ctx_used, block_size, dbg.c_str());
+            }
+        }
+        llama_clear_dflash_target_features(ctx_tgt);
+    }
+
+    void accept(llama_seq_id /*seq_id*/, uint16_t /*n_accepted*/, bool /*is_other*/) override {
+        // noop
+    }
+};
+
 // state of self-speculation (simple implementation, not ngram-map)
 struct common_speculative_impl_ngram_simple : public common_speculative_impl {
     common_params_speculative_ngram_map params;
@@ -1273,6 +1476,7 @@ std::string common_speculative_type_to_str(common_speculative_type type) {
         case COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE:  return "draft-simple";
         case COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3:  return "draft-eagle3";
         case COMMON_SPECULATIVE_TYPE_DRAFT_MTP:     return "draft-mtp";
+        case COMMON_SPECULATIVE_TYPE_DFLASH:        return "dflash";
         case COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE:  return "ngram-simple";
         case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K:   return "ngram-map-k";
         case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V: return "ngram-map-k4v";
@@ -1325,6 +1529,7 @@ int32_t common_speculative_n_max(const common_params_speculative * spec) {
             case COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE:
             case COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3:
             case COMMON_SPECULATIVE_TYPE_DRAFT_MTP:
+            case COMMON_SPECULATIVE_TYPE_DFLASH:
                 n_max = std::max(n_max, std::max(0, spec->draft.n_max));
                 break;
             case COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE:
@@ -1361,6 +1566,8 @@ common_speculative * common_speculative_init(common_params_speculative & params,
 
         bool has_draft_simple = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE));
         bool has_draft_eagle3 = false; // TODO PR-18039: if params.speculative.eagle3
+        bool has_draft_dflash = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DFLASH)) && params.dflash;
+        bool has_draft_model_path = !params.draft.mparams.path.empty();
         bool has_mtp = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DRAFT_MTP)) && params.draft.ctx_dft != nullptr;
 
         bool has_ngram_cache   = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_NGRAM_CACHE));
@@ -1370,7 +1577,7 @@ common_speculative * common_speculative_init(common_params_speculative & params,
         bool has_ngram_mod     = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_NGRAM_MOD));
 
         // when adding a new type - update here the logic above
-        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 9);
+        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 10);
 
         // this list here defines the priority of the speculators
         // the one with highest priority are listed first
@@ -1392,10 +1599,23 @@ common_speculative * common_speculative_init(common_params_speculative & params,
             configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_NGRAM_CACHE, params));
         }
         if (has_draft_simple) {
+            if (!has_draft_model_path) {
+                LOG_WRN("%s: draft model is not specified - cannot use 'draft' type\n", __func__);
+                has_draft_simple = false;
+            }
+        } else if (has_draft_model_path && !has_mtp && !has_draft_eagle3 && !has_draft_dflash) {
+            LOG_WRN("%s: draft model is specified but 'draft' speculative type is not explicitly enabled - enabling it\n", __func__);
+            has_draft_simple = true;
+        }
+
+        if (has_draft_simple) {
             configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE, params));
         }
         if (has_draft_eagle3) {
             configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3, params));
+        }
+        if (has_draft_dflash) {
+            configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DFLASH, params));
         }
         if (has_mtp) {
             configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DRAFT_MTP, params));
@@ -1414,6 +1634,10 @@ common_speculative * common_speculative_init(common_params_speculative & params,
             }
             case COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3: {
                 impls.push_back(std::make_unique<common_speculative_impl_draft_eagle3>(config.params, n_seq));
+                break;
+            }
+            case COMMON_SPECULATIVE_TYPE_DFLASH: {
+                impls.push_back(std::make_unique<common_speculative_impl_dflash>(config.params, n_seq, config.params.draft.ctx_tgt));
                 break;
             }
             case COMMON_SPECULATIVE_TYPE_DRAFT_MTP: {

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -75,7 +75,14 @@ int main(int argc, char ** argv) {
         }
 
         auto cparams = common_context_params_to_llama(params_dft);
+        if (params.speculative.dflash) {
+            cparams.target_model = model_tgt;
+        }
         ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams));
+
+        if (params.speculative.dflash) {
+            llama_set_dflash(ctx_tgt, model_dft.get());
+        }
 
         params.speculative.draft.ctx_tgt = ctx_tgt;
         params.speculative.draft.ctx_dft = ctx_dft.get();
@@ -83,7 +90,7 @@ int main(int argc, char ** argv) {
 
     // check if the context supports partial sequence removal
     const bool use_ckpt_tgt = (common_context_can_seq_rm(ctx_tgt)       == COMMON_CONTEXT_SEQ_RM_TYPE_FULL);
-    const bool use_ckpt_dft = (common_context_can_seq_rm(ctx_dft.get()) == COMMON_CONTEXT_SEQ_RM_TYPE_FULL);
+    const bool use_ckpt_dft = !params.speculative.dflash && (common_context_can_seq_rm(ctx_dft.get()) == COMMON_CONTEXT_SEQ_RM_TYPE_FULL);
 
     if (use_ckpt_tgt) {
         LOG_INF("speculative decoding will use checkpoints (context does not support partial sequence removal)\n");
@@ -130,8 +137,10 @@ int main(int argc, char ** argv) {
     common_sampler_ptr smpl(common_sampler_init(model_tgt, params.sampling));
 
     // eval the prompt
-    llama_decode(ctx_tgt,       llama_batch_get_one(inp.data(), inp.size() - 1));
-    llama_decode(ctx_dft.get(), llama_batch_get_one(inp.data(), inp.size() - 1));
+    llama_decode(ctx_tgt, llama_batch_get_one(inp.data(), inp.size() - 1));
+    if (!params.speculative.dflash) {
+        llama_decode(ctx_dft.get(), llama_batch_get_one(inp.data(), inp.size() - 1));
+    }
 
     // note: keep the last token separate!
     llama_token id_last = inp.back();
@@ -201,9 +210,11 @@ int main(int argc, char ** argv) {
             }
 
             {
-                ckpt.load_dft(ctx_dft.get(), seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY | LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
+                if (!params.speculative.dflash) {
+                    ckpt.load_dft(ctx_dft.get(), seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY | LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
 
-                llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), seq_id, ckpt.pos_max + 1, -1);
+                    llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), seq_id, ckpt.pos_max + 1, -1);
+                }
             }
         } else {
             // we have a previous (partial) draft to reuse from checkpoint restoration
@@ -227,10 +238,14 @@ int main(int argc, char ** argv) {
             llama_decode(ctx_tgt, batch_tgt);
         }
 
-        // evaluate the same batch with the draft model
-        {
+        if (!params.speculative.dflash) {
             // TODO: extend to support MTP, Eagle, etc. See server code for reference
             llama_decode(ctx_dft.get(), batch_tgt);
+        }
+
+        if (!common_speculative_process(spec, batch_tgt)) {
+            LOG_ERR("failed to process speculative batch\n");
+            break;
         }
 
         // only save the sampler sampler state if we use checkpoints
@@ -267,9 +282,11 @@ int main(int argc, char ** argv) {
             }
 
             {
-                ckpt.load_dft(ctx_dft.get(), seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY | LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
+                if (!params.speculative.dflash) {
+                    ckpt.load_dft(ctx_dft.get(), seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY | LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
 
-                llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), seq_id, ckpt.pos_max + 1, -1);
+                    llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), seq_id, ckpt.pos_max + 1, -1);
+                }
             }
 
             prompt_tgt.resize(ckpt.n_tokens);
@@ -320,8 +337,10 @@ int main(int argc, char ** argv) {
         {
             LOG_DBG("clear kv cache from any extra tokens, n_past = %d\n", n_past);
 
-            llama_memory_seq_rm(llama_get_memory(ctx_tgt),       seq_id, n_past, -1);
-            llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), seq_id, n_past, -1);
+            llama_memory_seq_rm(llama_get_memory(ctx_tgt), seq_id, n_past, -1);
+            if (!params.speculative.dflash) {
+                llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), seq_id, n_past, -1);
+            }
         }
 
         if ((params.n_predict >= 0 && n_predict > params.n_predict) || has_eos) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -381,6 +381,10 @@ extern "C" {
         bool swa_full;    // use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
                           // NOTE: setting to false when n_seq_max > 1 can cause bad performance in some cases
                           //       ref: https://github.com/ggml-org/llama.cpp/pull/13845#issuecomment-2924800573
+        // reference to the target model for DFlash/EAGLE3 speculative decoding
+        // used to share embeddings and extraction configuration
+        const struct llama_model * target_model;
+
         bool kv_unified;  // use a unified buffer across the input sequences when computing the attention
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
@@ -564,6 +568,11 @@ extern "C" {
     LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head_kv  (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_swa      (const struct llama_model * model);
+
+    // DFlash draft model metadata
+    LLAMA_API int32_t llama_model_dflash_block_size  (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_dflash_mask_token_id(const struct llama_model * model);
+    LLAMA_API int32_t llama_model_dflash_n_target_layers(const struct llama_model * model);
 
     // Get the model's RoPE frequency scaling factor
     LLAMA_API float llama_model_rope_freq_scale_train(const struct llama_model * model);
@@ -901,6 +910,27 @@ extern "C" {
                           size_t   size,
                     llama_seq_id   dest_seq_id,
            llama_state_seq_flags   flags);
+
+    // DFlash
+    LLAMA_API void llama_set_dflash(
+            struct llama_context * ctx,
+            const struct llama_model * model);
+
+    LLAMA_API const float * llama_get_dflash_target_features(struct llama_context * ctx);
+
+    // Clears the accumulated DFlash target-features buffer on ctx. Call this
+    // when starting a new draft "session" (e.g. in common_speculative_begin)
+    // so the buffer doesn't retain features from the previous request.
+    LLAMA_API void llama_clear_dflash_target_features(struct llama_context * ctx);
+
+    LLAMA_API void llama_set_dflash_accumulated_target_ctx(
+            struct llama_context * ctx,
+                   const float * data,
+                       int32_t   n_embd,
+                       int32_t   n_tokens);
+
+    LLAMA_API void llama_set_dflash_need_reserve(
+            struct llama_context * ctx);
 
     //
     // Decoding

--- a/scripts/bench-dflash.sh
+++ b/scripts/bench-dflash.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# DFlash speculative decoding bench harness.
+#
+# Runs llama-speculative-simple across drafter quants and prompt classes,
+# reporting acceptance rate and decode throughput. Each (drafter, prompt)
+# pair runs N times so variance is visible (DFlash bench has ±2-3pp
+# run-to-run variance even at temp=0 / fixed seed).
+#
+# VRAM requirement: ~22 GB free (target Q4_K_M ~18 GB + drafter ~1-3 GB +
+# compute). Coordinate centurion-llm scale-down before running.
+#
+# Usage:
+#   scripts/bench-dflash.sh [--quants Q4,Q6,Q8,BF16] [--runs 3] [--ctx 4096]
+#
+# Output goes to /tmp/dflash-bench-<timestamp>.md with a markdown summary
+# table at the bottom.
+#
+# Reference acceptance per vLLM PR #41703 on Gemma4-26B-A4B-it (similar
+# arch / Anbeeld-style drafter):
+#   - HumanEval prompts: ~44.69% accept
+#   - MT-Bench prompts:  ~21.68% accept
+# Our prompt set covers both classes for direct comparison.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/build-cuda/bin/llama-speculative-simple"
+TARGET="$ROOT/models/gemma-4-31B-it-Q4_K_M.gguf"
+DRAFTER_DIR="$ROOT/models/dflash-gemma4-31b-gguf"
+TS=$(date +%Y%m%d-%H%M%S)
+OUT="/tmp/dflash-bench-$TS.md"
+
+QUANTS="Q4_K_M,Q6_K,Q8_0,bf16"
+RUNS=3
+CTX=4096
+
+while (( $# )); do
+    case "$1" in
+        --quants) QUANTS="$2"; shift 2 ;;
+        --runs)   RUNS="$2";   shift 2 ;;
+        --ctx)    CTX="$2";    shift 2 ;;
+        --help|-h)
+            sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed -E 's/^# ?//' | head -n -1
+            exit 0 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Prompts: one MT-Bench-class (conversational), one HumanEval-class (code).
+MTBENCH_PROMPT="Write a 50-word paragraph about speculative decoding."
+HUMANEVAL_PROMPT='Complete the Python function:
+def fibonacci(n: int) -> list[int]:
+    """Return the first n Fibonacci numbers as a list."""'
+
+# Sanity: VRAM and binary.
+if [[ ! -x "$BIN" ]]; then
+    echo "missing or non-executable: $BIN" >&2
+    echo "build with: cmake --build build-cuda --target llama-speculative-simple -j" >&2
+    exit 1
+fi
+if [[ ! -f "$TARGET" ]]; then
+    echo "missing target model: $TARGET" >&2
+    exit 1
+fi
+
+FREE_MIB=$(nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits | head -1)
+if (( FREE_MIB < 20000 )); then
+    echo "WARNING: only ${FREE_MIB} MiB free on GPU; need ~22000. Bench will likely OOM." >&2
+    echo "Coordinate centurion-llm scale-down via snoop-kube first." >&2
+    read -r -p "Continue anyway? [y/N] " ans
+    [[ "$ans" == "y" || "$ans" == "Y" ]] || exit 1
+fi
+
+run_one() {
+    local label="$1" drafter="$2" prompt="$3" out_dir="$4"
+    local err="$out_dir/$label.err"
+    local out="$out_dir/$label.out"
+
+    timeout 240 "$BIN" \
+        -m "$TARGET" \
+        -md "$drafter" \
+        --dflash \
+        -p "$prompt" \
+        -n 128 -c "$CTX" -ngl 99 -ngld 99 -fa on \
+        --temp 0 --seed 1 \
+        --cache-type-k q8_0 --cache-type-v q8_0 \
+        > "$out" 2> "$err" || true
+
+    local acc tok
+    acc=$(grep 'accept    =' "$err" | tail -1 | awk -F'= ' '{print $2}' | tr -d ' ')
+    tok=$(grep 'decoded ' "$err" | tail -1 | awk '{print $(NF-1), $NF}')
+    echo "$acc|$tok"
+}
+
+OUT_DIR="/tmp/dflash-bench-$TS-runs"
+mkdir -p "$OUT_DIR"
+
+echo "# DFlash bench $TS" | tee "$OUT"
+echo "" | tee -a "$OUT"
+echo "Target: $(basename "$TARGET")" | tee -a "$OUT"
+echo "Build: $(cd "$ROOT" && git rev-parse --short HEAD)" | tee -a "$OUT"
+echo "Quants: $QUANTS" | tee -a "$OUT"
+echo "Runs per condition: $RUNS" | tee -a "$OUT"
+echo "ctx: $CTX, q8_0 KV cache" | tee -a "$OUT"
+echo "" | tee -a "$OUT"
+echo "| drafter | prompt | run 1 | run 2 | run 3 | mean | tok/s (last run) |" | tee -a "$OUT"
+echo "|---|---|---:|---:|---:|---:|---|" | tee -a "$OUT"
+
+IFS=, read -ra QUANT_ARR <<< "$QUANTS"
+for quant in "${QUANT_ARR[@]}"; do
+    drafter="$DRAFTER_DIR/gemma4-31b-it-dflash-${quant}.gguf"
+    [[ -f "$drafter" ]] || { echo "skip (missing): $drafter" >&2; continue; }
+
+    for prompt_label in "MT-Bench" "HumanEval"; do
+        if [[ "$prompt_label" == "MT-Bench" ]]; then
+            prompt="$MTBENCH_PROMPT"
+        else
+            prompt="$HUMANEVAL_PROMPT"
+        fi
+
+        acc_sum=0
+        results=()
+        last_tok=""
+        for ((r=1; r<=RUNS; r++)); do
+            label="${quant}_${prompt_label}_${r}"
+            result=$(run_one "$label" "$drafter" "$prompt" "$OUT_DIR")
+            acc=$(echo "$result" | cut -d'|' -f1)
+            tok=$(echo "$result" | cut -d'|' -f2)
+            results+=("$acc")
+            last_tok="$tok"
+
+            num=$(echo "$acc" | tr -d '%')
+            if [[ "$num" =~ ^[0-9.]+$ ]]; then
+                acc_sum=$(awk -v s="$acc_sum" -v a="$num" 'BEGIN{print s+a}')
+            fi
+        done
+
+        mean=$(awk -v s="$acc_sum" -v n="$RUNS" 'BEGIN{printf "%.2f%%", s/n}')
+        row="| $quant | $prompt_label | ${results[0]:-—} | ${results[1]:-—} | ${results[2]:-—} | $mean | $last_tok |"
+        echo "$row" | tee -a "$OUT"
+    done
+done
+
+echo "" | tee -a "$OUT"
+echo "Per-run stderr at $OUT_DIR/*.err" | tee -a "$OUT"
+echo "" | tee -a "$OUT"
+echo "Done. Summary written to $OUT"

--- a/scripts/compare-dflash-weights.py
+++ b/scripts/compare-dflash-weights.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Compare safetensors bf16 weights against GGUF Q*-quantized weights, per tensor.
+
+Used to verify GGUF conversion fidelity for DFlash drafter models. Surfaces
+per-tensor relative RMS error after dequantization. Uniform small errors
+(~quantization noise) indicate a clean conversion; outlier tensors suggest
+a converter bug (wrong shape, missing tensor, miscalibrated scale).
+
+Usage:
+    scripts/compare-dflash-weights.py <safetensors_path> <gguf_path>
+
+Defaults to the Anbeeld/z-lab Gemma-4-31B-it-DFlash files under $MODELS
+when no args given.
+"""
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+
+import numpy as np
+from safetensors import safe_open
+
+try:
+    import gguf
+    import gguf.quants
+except ImportError:
+    sys.stderr.write("gguf-py not found. Install via the convert venv:\n")
+    sys.stderr.write("  source .venv-convert/bin/activate && pip install gguf\n")
+    sys.exit(1)
+
+
+SAFETENSORS_DEFAULT = os.path.expanduser(
+    "~/ht/forks/ht-llama.cpp/models/dflash-gemma4-31b/model.safetensors"
+)
+GGUF_DEFAULT = os.path.expanduser(
+    "~/ht/forks/ht-llama.cpp/models/dflash-gemma4-31b-gguf/gemma4-31b-it-dflash-Q6_K.gguf"
+)
+
+
+def bf16_bytes_to_fp32(buf: bytes) -> np.ndarray:
+    """bf16 → fp32: shift mantissa left 16 bits, reinterpret. Avoids torch dep."""
+    u16 = np.frombuffer(buf, dtype=np.uint16)
+    u32 = u16.astype(np.uint32) << 16
+    return u32.view(np.float32)
+
+
+def build_name_map(num_layers: int = 5) -> dict[str, str]:
+    """safetensors → GGUF tensor name mapping for DFlash drafters."""
+    name_map = {
+        "fc.weight": "dflash_fc.weight",
+        "hidden_norm.weight": "dflash_hidden_norm.weight",
+        "norm.weight": "output_norm.weight",
+    }
+    for i in range(num_layers):
+        name_map[f"layers.{i}.input_layernorm.weight"] = f"blk.{i}.attn_norm.weight"
+        name_map[f"layers.{i}.post_attention_layernorm.weight"] = f"blk.{i}.post_attention_norm.weight"
+        name_map[f"layers.{i}.self_attn.q_proj.weight"] = f"blk.{i}.attn_q.weight"
+        name_map[f"layers.{i}.self_attn.k_proj.weight"] = f"blk.{i}.attn_k.weight"
+        name_map[f"layers.{i}.self_attn.v_proj.weight"] = f"blk.{i}.attn_v.weight"
+        name_map[f"layers.{i}.self_attn.o_proj.weight"] = f"blk.{i}.attn_output.weight"
+        name_map[f"layers.{i}.self_attn.q_norm.weight"] = f"blk.{i}.attn_q_norm.weight"
+        name_map[f"layers.{i}.self_attn.k_norm.weight"] = f"blk.{i}.attn_k_norm.weight"
+        name_map[f"layers.{i}.mlp.down_proj.weight"] = f"blk.{i}.ffn_down.weight"
+        name_map[f"layers.{i}.mlp.gate_proj.weight"] = f"blk.{i}.ffn_gate.weight"
+        name_map[f"layers.{i}.mlp.up_proj.weight"] = f"blk.{i}.ffn_up.weight"
+    return name_map
+
+
+def main() -> int:
+    st_path = sys.argv[1] if len(sys.argv) > 1 else SAFETENSORS_DEFAULT
+    gguf_path = sys.argv[2] if len(sys.argv) > 2 else GGUF_DEFAULT
+
+    print(f"Loading GGUF:        {gguf_path}")
+    reader = gguf.GGUFReader(gguf_path)
+    gguf_tensors = {t.name: t for t in reader.tensors}
+    print(f"  {len(gguf_tensors)} tensors")
+
+    print(f"Loading safetensors: {st_path}")
+    with safe_open(st_path, framework="numpy") as f:
+        st_keys = sorted(f.keys())
+    print(f"  {len(st_keys)} tensors")
+
+    num_layers = sum(1 for k in st_keys if k.startswith("layers.") and k.endswith(".input_layernorm.weight"))
+    name_map = build_name_map(num_layers)
+
+    results: list[tuple[str, str, tuple[int, ...], str, float, float, float, float]] = []
+    with open(st_path, "rb") as fh:
+        header_size = struct.unpack("<Q", fh.read(8))[0]
+        header = json.loads(fh.read(header_size).decode("utf-8"))
+        data_start = 8 + header_size
+
+        for st_name in sorted(header.keys()):
+            if st_name == "__metadata__":
+                continue
+            meta = header[st_name]
+            if meta["dtype"] != "BF16":
+                continue
+            gguf_name = name_map.get(st_name)
+            if gguf_name is None or gguf_name not in gguf_tensors:
+                continue
+
+            offset_start, offset_end = meta["data_offsets"]
+            fh.seek(data_start + offset_start)
+            bf16_buf = fh.read(offset_end - offset_start)
+            st_fp32 = bf16_bytes_to_fp32(bf16_buf).reshape(meta["shape"])
+
+            gt = gguf_tensors[gguf_name]
+            gt_data = gguf.quants.dequantize(gt.data, gt.tensor_type)
+            gt_data = gt_data.reshape(list(gt.shape[::-1]))
+
+            if gt_data.shape != st_fp32.shape:
+                if gt_data.shape == st_fp32.shape[::-1]:
+                    gt_data = gt_data.T
+                else:
+                    print(f"  SHAPE MISMATCH {st_name}: st={st_fp32.shape} gguf={gt_data.shape}")
+                    continue
+
+            diff = (gt_data - st_fp32).astype(np.float32)
+            rms_err = float(np.sqrt((diff ** 2).mean()))
+            rms_val = float(np.sqrt((st_fp32.astype(np.float32) ** 2).mean()))
+            rel_err = rms_err / (rms_val + 1e-12)
+            max_abs_err = float(np.abs(diff).max())
+            results.append((st_name, gguf_name, st_fp32.shape, gt.tensor_type.name, rms_val, rms_err, rel_err, max_abs_err))
+
+    results.sort(key=lambda r: -r[6])
+
+    print()
+    print("Per-tensor comparison (sorted by relative RMS error, worst first):")
+    hdr = f"{'safetensors name':<55}{'GGUF type':<10}{'shape':<22}{'rms_val':>10}{'rms_err':>12}{'rel_err':>10}{'max_abs_err':>14}"
+    print(hdr)
+    for st_name, _, shape, qt, rms_val, rms_err, rel_err, max_abs_err in results:
+        print(f"{st_name:<55}{qt:<10}{str(shape):<22}{rms_val:>10.4f}{rms_err:>12.6f}{rel_err:>10.5f}{max_abs_err:>14.6f}")
+
+    if results:
+        rel_errs = [r[6] for r in results]
+        print()
+        print(f"Total tensors compared: {len(results)}")
+        print(f"Median relative RMS error: {np.median(rel_errs):.5f}")
+        print(f"Max    relative RMS error: {max(rel_errs):.5f}  ({results[0][0]})")
+        print(f"Mean   relative RMS error: {np.mean(rel_errs):.5f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke-any-mrouter.sh
+++ b/scripts/smoke-any-mrouter.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Smoke-test the "any" sentinel + last_used_ms field on a deployed unified-llm router.
+#
+# Validates the surface added/refreshed in mission m-20260524-165127-3bb03b:
+#   1. GET /v1/models — confirm per-model `last_used_ms` field is present (int).
+#   2. POST /v1/chat/completions with model="any" — confirm response.model is the
+#      resolved instance id (not the literal "any"), and capture which model the
+#      router picked.
+#   3. (Optional) verify 4xx is returned with the right error.type when the
+#      sentinel is sent to a router with nothing resident. Skipped by default
+#      because emptying the router cache is destructive; gate behind --test-empty.
+#
+# Usage:
+#   scripts/smoke-any-mrouter.sh [URL ...]
+#     URL defaults: cluster peers as of mission m-20260524 (titan/centurion/lithium)
+#   scripts/smoke-any-mrouter.sh --test-empty URL
+#     Adds the destructive "no-model-resident" check (POST /unload_all first).
+#
+# Exit code: 0 if all reachable peers pass; non-zero if any reachable peer fails.
+# Unreachable peers (connection refused / timeout) are reported but do not fail.
+
+set -uo pipefail
+
+DEFAULT_PEERS=(
+    "http://192.168.8.158:30184"   # titan
+    "http://192.168.8.170:30192"   # centurion
+    "http://192.168.8.119:30187"   # lithium
+)
+TEST_EMPTY=0
+PEERS=()
+
+while (( $# )); do
+    case "$1" in
+        --test-empty) TEST_EMPTY=1; shift ;;
+        --help|-h)
+            sed -n '2,/^set -uo/p' "${BASH_SOURCE[0]}" | sed -E 's/^# ?//' | head -n -1
+            exit 0 ;;
+        http*) PEERS+=("$1"); shift ;;
+        *)     echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if (( ${#PEERS[@]} == 0 )); then
+    PEERS=("${DEFAULT_PEERS[@]}")
+fi
+
+GREEN=$'\033[32m'; RED=$'\033[31m'; YELLOW=$'\033[33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+pass_count=0; fail_count=0; skip_count=0
+
+check_models_endpoint() {
+    local peer="$1"
+    local body
+    body=$(curl -sS --max-time 5 "$peer/v1/models" 2>/dev/null) || return 2
+
+    local has_data
+    has_data=$(echo "$body" | jq -e '.data | type == "array"' 2>/dev/null) || return 3
+
+    local n_models
+    n_models=$(echo "$body" | jq '.data | length')
+    [[ "$n_models" -ge 1 ]] || return 4
+
+    # Every model entry must have a last_used_ms int field
+    local n_with_field
+    n_with_field=$(echo "$body" | jq '[.data[] | select(.last_used_ms != null and (.last_used_ms | type == "number"))] | length')
+    if [[ "$n_with_field" -ne "$n_models" ]]; then
+        return 5  # field missing on at least one model
+    fi
+    echo "$n_models"
+    return 0
+}
+
+check_any_routing() {
+    local peer="$1"
+    local body
+    # use a tiny, fast-to-complete request
+    body=$(curl -sS --max-time 60 -X POST "$peer/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d '{"model":"any","messages":[{"role":"user","content":"reply with just OK"}],"max_tokens":4,"stream":false}' 2>/dev/null) || return 2
+
+    # If 4xx, body has .error.message
+    local err
+    err=$(echo "$body" | jq -r '.error.message // empty' 2>/dev/null)
+    if [[ -n "$err" ]]; then
+        # 4xx case — only acceptable if testing empty router
+        echo "4xx: $err"
+        return 10
+    fi
+
+    local resolved
+    resolved=$(echo "$body" | jq -r '.model // empty' 2>/dev/null)
+    if [[ -z "$resolved" ]]; then
+        return 3  # malformed
+    fi
+    if [[ "$resolved" == "any" ]]; then
+        return 4  # router didn't rewrite — bug
+    fi
+    echo "$resolved"
+    return 0
+}
+
+for peer in "${PEERS[@]}"; do
+    printf "\n${peer} "
+    # Step 1: /v1/models
+    n_models=$(check_models_endpoint "$peer")
+    rc=$?
+    case $rc in
+        0) printf "%s/v1/models%s ✓ (%s models, last_used_ms present) " "$GREEN" "$RESET" "$n_models" ;;
+        2) printf "%sUNREACHABLE%s (skipped) " "$YELLOW" "$RESET"; ((skip_count+=1)); continue ;;
+        3) printf "%s/v1/models FAIL%s (no .data array)\n" "$RED" "$RESET"; ((fail_count+=1)); continue ;;
+        4) printf "%s/v1/models FAIL%s (zero models in router)\n" "$RED" "$RESET"; ((fail_count+=1)); continue ;;
+        5) printf "%s/v1/models FAIL%s (last_used_ms missing on at least one model)\n" "$RED" "$RESET"; ((fail_count+=1)); continue ;;
+    esac
+
+    # Step 2: model="any" resolution
+    resolved=$(check_any_routing "$peer")
+    rc=$?
+    case $rc in
+        0)  printf "→ %sany resolved to '%s'%s\n" "$GREEN" "$resolved" "$RESET"; ((pass_count+=1)) ;;
+        2)  printf "→ %sUNREACHABLE on chat endpoint%s\n" "$YELLOW" "$RESET"; ((skip_count+=1)) ;;
+        3)  printf "→ %sany route FAIL (malformed response)%s\n" "$RED" "$RESET"; ((fail_count+=1)) ;;
+        4)  printf "→ %sany route FAIL (router echoed 'any' — rewrite did not fire)%s\n" "$RED" "$RESET"; ((fail_count+=1)) ;;
+        10) # 4xx — only OK if test-empty mode
+            if (( TEST_EMPTY )); then
+                printf "→ %sany on empty router returned 4xx (expected)%s — %s\n" "$GREEN" "$RESET" "$resolved"
+                ((pass_count+=1))
+            else
+                printf "→ %sany route FAIL (4xx: %s — router has nothing resident, prime a model first)%s\n" "$RED" "$resolved" "$RESET"
+                ((fail_count+=1))
+            fi
+            ;;
+    esac
+done
+
+echo
+echo "${DIM}---${RESET}"
+printf "Pass: %s%d%s  Fail: %s%d%s  Skip: %s%d%s\n" "$GREEN" "$pass_count" "$RESET" "$RED" "$fail_count" "$RESET" "$YELLOW" "$skip_count" "$RESET"
+
+if (( fail_count > 0 )); then
+    exit 1
+fi
+exit 0

--- a/scripts/smoke-dflash-deployed.sh
+++ b/scripts/smoke-dflash-deployed.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Post-deploy smoke for DFlash speculative decoding via a router preset.
+#
+# Verifies:
+#   1. Router exposes a dflash-enabled model (preset args contain --dflash + --model-draft)
+#   2. POST /v1/chat/completions with that model id loads the drafter alongside the target
+#      and produces a non-empty completion
+#   3. (optional) /v1/models for that entry reports last_used_ms bumped post-request
+#
+# Usage:
+#   scripts/smoke-dflash-deployed.sh <peer-url> <model-id>
+#     e.g. scripts/smoke-dflash-deployed.sh http://192.168.8.158:30184 gemma-4-31b-dflash
+#
+# Exit 0 on full pass.
+
+set -uo pipefail
+
+if (( $# < 2 )); then
+    echo "usage: $0 <peer-url> <model-id>" >&2
+    exit 2
+fi
+
+PEER="$1"
+MODEL="$2"
+
+GREEN=$'\033[32m'; RED=$'\033[31m'; YELLOW=$'\033[33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+fail=0
+
+step() {
+    printf "\n${DIM}— %s${RESET}\n" "$1"
+}
+
+ok()   { printf "  ${GREEN}✓${RESET} %s\n" "$1"; }
+bad()  { printf "  ${RED}✗${RESET} %s\n" "$1"; fail=$((fail+1)); }
+warn() { printf "  ${YELLOW}!${RESET} %s\n" "$1"; }
+
+step "1. /v1/models — verify preset exposes dflash + drafter"
+body=$(curl -sS --max-time 5 "$PEER/v1/models" 2>/dev/null)
+[[ -z "$body" ]] && { bad "no response from /v1/models — peer unreachable"; exit 1; }
+
+entry=$(echo "$body" | jq -e ".data[] | select(.id == \"$MODEL\")" 2>/dev/null)
+if [[ -z "$entry" ]]; then
+    bad "model id '$MODEL' not present in /v1/models"
+    echo "  available: $(echo "$body" | jq -r '.data[].id' | head -20 | tr '\n' ',' | sed 's/,$//')" >&2
+    exit 1
+fi
+ok "model '$MODEL' present in router"
+
+args=$(echo "$entry" | jq -r '.status.args | join(" ")')
+if echo "$args" | grep -qE '(^| )--dflash( |$)'; then
+    ok "preset args carry --dflash"
+else
+    bad "preset args do NOT carry --dflash"
+    echo "  args: $args" >&2
+fi
+
+if echo "$args" | grep -qE '(^| )(--model-draft|-md|--spec-draft-model) '; then
+    drafter=$(echo "$args" | grep -oE '(--model-draft|-md|--spec-draft-model) [^ ]+' | awk '{print $2}')
+    ok "preset args carry drafter: $drafter"
+else
+    bad "preset args do NOT carry --model-draft / --spec-draft-model"
+fi
+
+step "2. POST /v1/chat/completions — drafter loads + non-empty completion"
+last_used_before=$(echo "$entry" | jq -r '.last_used_ms // 0')
+
+# enable_thinking:false to keep Gemma4-style targets from burning the small max_tokens
+# budget on reasoning_content. max_tokens=64 gives enough headroom even for verbose templates.
+t_start=$(date +%s%N)
+response=$(curl -sS --max-time 120 -X POST "$PEER/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with exactly the word OK\"}],\"max_tokens\":64,\"stream\":false,\"temperature\":0,\"chat_template_kwargs\":{\"enable_thinking\":false}}" 2>/dev/null)
+t_end=$(date +%s%N)
+elapsed_ms=$(( (t_end - t_start) / 1000000 ))
+
+err=$(echo "$response" | jq -r '.error.message // empty' 2>/dev/null)
+if [[ -n "$err" ]]; then
+    bad "chat completion failed: $err"
+    exit 1
+fi
+
+# content can land in .content (normal) or .reasoning_content (thinking-mode models like Gemma4).
+# Either one means the model actually generated something.
+content=$(echo "$response" | jq -r '.choices[0].message.content // empty' 2>/dev/null)
+reasoning=$(echo "$response" | jq -r '.choices[0].message.reasoning_content // empty' 2>/dev/null)
+resolved_model=$(echo "$response" | jq -r '.model // empty' 2>/dev/null)
+draft_n=$(echo "$response" | jq -r '.timings.draft_n // 0' 2>/dev/null)
+draft_accepted=$(echo "$response" | jq -r '.timings.draft_n_accepted // 0' 2>/dev/null)
+
+if [[ -n "$content" ]]; then
+    ok "completion returned ($elapsed_ms ms): '${content:0:60}'"
+elif [[ -n "$reasoning" ]]; then
+    ok "completion in reasoning_content ($elapsed_ms ms): '${reasoning:0:60}'"
+else
+    bad "completion content AND reasoning_content are both empty"
+fi
+
+if (( draft_n > 0 )); then
+    pct=$(awk "BEGIN{printf \"%.2f\", 100*$draft_accepted/$draft_n}")
+    ok "drafter active: $draft_n drafted, $draft_accepted accepted (${pct}%)"
+else
+    bad "drafter inactive: timings.draft_n == 0 — dflash did not engage"
+fi
+
+if [[ "$resolved_model" == "$MODEL" ]]; then
+    ok "response.model == request.model ($MODEL)"
+else
+    warn "response.model='$resolved_model' (differs from request — router rewrite?)"
+fi
+
+step "3. /v1/models — last_used_ms bumped after request"
+body2=$(curl -sS --max-time 5 "$PEER/v1/models" 2>/dev/null)
+last_used_after=$(echo "$body2" | jq -r ".data[] | select(.id == \"$MODEL\") | .last_used_ms // 0")
+if [[ "$last_used_after" -gt "$last_used_before" ]]; then
+    ok "last_used_ms advanced: $last_used_before → $last_used_after"
+else
+    warn "last_used_ms did not advance ($last_used_before → $last_used_after) — router may not be tracking POST as a usage event"
+fi
+
+step "4. Sanity — second request to confirm drafter stays warm"
+t_start=$(date +%s%N)
+response2=$(curl -sS --max-time 60 -X POST "$PEER/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with just YES\"}],\"max_tokens\":64,\"stream\":false,\"temperature\":0,\"chat_template_kwargs\":{\"enable_thinking\":false}}" 2>/dev/null)
+t_end=$(date +%s%N)
+elapsed_ms2=$(( (t_end - t_start) / 1000000 ))
+
+content2=$(echo "$response2" | jq -r '.choices[0].message.content // empty' 2>/dev/null)
+reasoning2=$(echo "$response2" | jq -r '.choices[0].message.reasoning_content // empty' 2>/dev/null)
+if [[ -n "$content2" || -n "$reasoning2" ]]; then
+    ok "second request ($elapsed_ms2 ms): '${content2:-$reasoning2}'"
+else
+    bad "second request returned empty"
+fi
+
+echo
+if (( fail > 0 )); then
+    echo "${RED}FAIL${RESET}: $fail check(s) failed"
+    exit 1
+fi
+echo "${GREEN}PASS${RESET}: dflash preset wired correctly on $PEER for $MODEL"
+exit 0

--- a/scripts/smoke-dflash-no-nan.sh
+++ b/scripts/smoke-dflash-no-nan.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression smoke: catch the dflash NaN-logits bug class (mission m-20260527-103737).
+#
+# Bug profile: server-side spec_decode integration emits NaN drafter logits on the
+# /v1/chat/completions path (jinja chat template). Drafter argmaxes to <pad> for every
+# position, target rejects every draft, accept rate is 0%. dflash silently adds zero
+# value while consuming GPU cycles.
+#
+# This script:
+#   1. POSTs a chat completion to a deployed dflash router preset
+#   2. Asserts the response had a non-zero acceptance count (drafter produced at least
+#      ONE valid logit that target accepted)
+#   3. Reports per-run + aggregate accept rate
+#
+# Usage:
+#   scripts/smoke-dflash-no-nan.sh <peer-url> <dflash-model-id> [N_RUNS=3]
+#   e.g. scripts/smoke-dflash-no-nan.sh http://192.168.8.158:30184 gemma-4-31b-dflash-Q6_K
+#
+# Override: SMOKE_RUNS=10 scripts/smoke-dflash-no-nan.sh ...
+#
+# Exit 0: no NaN signature, healthy accept count
+# Exit 1: NaN-pattern detected (drafts proposed, zero accepts across all runs)
+# Exit 2: bad request / unreachable peer
+#
+# CI integration suggestion:
+#   - run as part of a deploy-verify step against a known dflash peer
+#   - run multiple consecutive requests (SMOKE_RUNS=5+) to catch intermittent NaN
+#   - target the /v1/chat/completions path specifically — the bug class does NOT
+#     manifest on /v1/completions (jinja chat template is the trigger)
+
+set -uo pipefail
+
+if (( $# < 2 )); then
+    echo "usage: $0 <peer-url> <dflash-model-id> [N_RUNS]" >&2
+    exit 2
+fi
+
+PEER="$1"
+MODEL="$2"
+N_RUNS="${3:-${SMOKE_RUNS:-3}}"
+
+GREEN=$'\033[32m'; RED=$'\033[31m'; YELLOW=$'\033[33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+
+total_drafted=0
+total_accepted=0
+fail_runs=0
+
+for r in $(seq 1 "$N_RUNS"); do
+    body=$(curl -sS --max-time 60 -X POST "$PEER/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Write five short haikus about the ocean.\"}],\"max_tokens\":128,\"stream\":false,\"temperature\":0,\"chat_template_kwargs\":{\"enable_thinking\":false}}" 2>/dev/null)
+
+    if [[ -z "$body" ]]; then
+        echo "${RED}FAIL run $r${RESET}: empty response from $PEER"
+        exit 2
+    fi
+
+    drafted=$(echo "$body" | jq -r '.timings.draft_n // 0')
+    accepted=$(echo "$body" | jq -r '.timings.draft_n_accepted // 0')
+    pred=$(echo "$body" | jq -r '.usage.completion_tokens // 0')
+    finish=$(echo "$body" | jq -r '.choices[0].finish_reason // "?"')
+
+    total_drafted=$((total_drafted + drafted))
+    total_accepted=$((total_accepted + accepted))
+
+    if (( drafted >= 50 && accepted == 0 )); then
+        echo "${RED}FAIL run $r${RESET}: $drafted drafted, $accepted accepted, finish=$finish — NaN signature"
+        fail_runs=$((fail_runs + 1))
+    else
+        local_rate=$(awk -v a="$accepted" -v d="$drafted" 'BEGIN { printf "%.2f", (d > 0 ? 100*a/d : 0) }')
+        echo "${DIM}run $r${RESET}: $drafted drafted, $accepted accepted (${local_rate}%), $pred tokens, finish=$finish"
+    fi
+done
+
+if (( total_drafted == 0 )); then
+    echo "${YELLOW}WARN${RESET}: zero drafts proposed across $N_RUNS runs — dflash may not be engaged at all"
+    exit 1
+fi
+
+overall_rate=$(awk -v a="$total_accepted" -v d="$total_drafted" 'BEGIN { printf "%.2f", 100*a/d }')
+
+if (( fail_runs > 0 )); then
+    echo
+    echo "${RED}FAIL${RESET}: $fail_runs / $N_RUNS runs hit the NaN signature (drafts >=50, accepts 0)"
+    echo "Overall: $total_accepted / $total_drafted = ${overall_rate}% accept across $N_RUNS runs"
+    exit 1
+fi
+
+if (( total_accepted == 0 )); then
+    echo
+    echo "${RED}FAIL${RESET}: zero total accepts across $N_RUNS runs ($total_drafted drafted) — likely NaN"
+    exit 1
+fi
+
+echo
+echo "${GREEN}PASS${RESET}: $total_accepted / $total_drafted accepts = ${overall_rate}% across $N_RUNS runs (NaN signature absent)"
+exit 0

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -136,6 +136,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_KIMI_LINEAR,      "kimi-linear"      },
     { LLM_ARCH_TALKIE,           "talkie"           },
     { LLM_ARCH_MELLUM,           "mellum"           },
+    { LLM_ARCH_DFLASH,           "dflash"           },
     { LLM_ARCH_UNKNOWN,          "(unknown)"        },
 };
 
@@ -296,6 +297,10 @@ static const std::map<llm_kv, const char *> LLM_KV_NAMES = {
     { LLM_KV_DENSE_2_FEAT_OUT,       "%s.dense_2_feat_out"  },
     { LLM_KV_DENSE_3_FEAT_IN,        "%s.dense_3_feat_in"   },
     { LLM_KV_DENSE_3_FEAT_OUT,       "%s.dense_3_feat_out"  },
+    { LLM_KV_DFLASH_TARGET_LAYER_IDS,     "%s.dflash.target_layer_ids"     },
+    { LLM_KV_DFLASH_BLOCK_SIZE,           "%s.dflash.block_size"           },
+    { LLM_KV_DFLASH_MASK_TOKEN_ID,        "%s.dflash.mask_token_id"        },
+    { LLM_KV_DFLASH_N_TARGET_FEATURES,    "%s.dflash.n_target_features"    },
 
     { LLM_KV_TOKENIZER_MODEL,                "tokenizer.ggml.model"                    },
     { LLM_KV_TOKENIZER_PRE,                  "tokenizer.ggml.pre"                      },
@@ -453,6 +458,8 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
     { LLM_TENSOR_ATTN_K_B,                               "blk.%d.attn_k_b" },
     { LLM_TENSOR_ATTN_V_B,                               "blk.%d.attn_v_b" },
     { LLM_TENSOR_NEXTN_EH_PROJ,                          "blk.%d.nextn.eh_proj" },
+    { LLM_TENSOR_DFLASH_FC,                              "dflash_fc" },
+    { LLM_TENSOR_DFLASH_HIDDEN_NORM,                     "dflash_hidden_norm" },
     { LLM_TENSOR_NEXTN_EMBED_TOKENS,                     "blk.%d.nextn.embed_tokens" },
     { LLM_TENSOR_NEXTN_ENORM,                            "blk.%d.nextn.enorm" },
     { LLM_TENSOR_NEXTN_HNORM,                            "blk.%d.nextn.hnorm" },
@@ -578,6 +585,8 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
     {LLM_TENSOR_CLS_NORM,                   {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL}},
     {LLM_TENSOR_DENSE_2_OUT,                {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL_MAT}}, // Dense layer output
     {LLM_TENSOR_DENSE_3_OUT,                {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL_MAT}}, // Dense layer output
+    {LLM_TENSOR_DFLASH_FC,                  {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL_MAT}},
+    {LLM_TENSOR_DFLASH_HIDDEN_NORM,         {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL}},
     {LLM_TENSOR_OUTPUT_NORM,                {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL}},
     {LLM_TENSOR_OUTPUT_NORM_LFM2,           {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL}},
     {LLM_TENSOR_DEC_OUTPUT_NORM,            {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL}},
@@ -780,9 +789,11 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
 };
 
 LLM_KV::LLM_KV(llm_arch arch, const char * suffix) : arch(arch), suffix(suffix) {}
+LLM_KV::LLM_KV(llm_arch arch, const std::string & arch_name_override, const char * suffix) : arch(arch), suffix(suffix), arch_name_override(arch_name_override) {}
 
 std::string LLM_KV::operator()(llm_kv kv) const {
-    std::string name = ::format(LLM_KV_NAMES.at(kv), LLM_ARCH_NAMES.at(arch));
+    const char * arch_name = arch_name_override.empty() ? LLM_ARCH_NAMES.at(arch) : arch_name_override.c_str();
+    std::string name = ::format(LLM_KV_NAMES.at(kv), arch_name);
 
     if (suffix != nullptr) {
         name += ".";
@@ -827,8 +838,13 @@ const char * llm_arch_name(llm_arch arch) {
 }
 
 llm_arch llm_arch_from_string(const std::string & name) {
+    std::string base_name = name;
+    if (base_name.size() > 6 && base_name.substr(base_name.size() - 6) == "-draft") {
+        base_name = base_name.substr(0, base_name.size() - 6);
+    }
+
     for (const auto & kv : LLM_ARCH_NAMES) { // NOLINT
-        if (kv.second == name) {
+        if (kv.second == base_name) {
             return kv.first;
         }
     }

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -140,6 +140,7 @@ enum llm_arch {
     LLM_ARCH_KIMI_LINEAR,
     LLM_ARCH_TALKIE,
     LLM_ARCH_MELLUM,
+    LLM_ARCH_DFLASH,
     LLM_ARCH_UNKNOWN,
 };
 
@@ -351,6 +352,12 @@ enum llm_kv {
     LLM_KV_DENSE_2_FEAT_OUT,
     LLM_KV_DENSE_3_FEAT_IN,
     LLM_KV_DENSE_3_FEAT_OUT,
+
+    // DFlash speculative decoding
+    LLM_KV_DFLASH_TARGET_LAYER_IDS,
+    LLM_KV_DFLASH_BLOCK_SIZE,
+    LLM_KV_DFLASH_MASK_TOKEN_ID,
+    LLM_KV_DFLASH_N_TARGET_FEATURES,
 };
 
 enum llm_tensor {
@@ -562,6 +569,8 @@ enum llm_tensor {
     LLM_TENSOR_NEXTN_HNORM,
     LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD,
     LLM_TENSOR_NEXTN_SHARED_HEAD_NORM,
+    LLM_TENSOR_DFLASH_FC,
+    LLM_TENSOR_DFLASH_HIDDEN_NORM,
 };
 
 enum llm_tensor_layer {
@@ -572,9 +581,11 @@ enum llm_tensor_layer {
 
 struct LLM_KV {
     LLM_KV(llm_arch arch, const char * suffix = nullptr);
+    LLM_KV(llm_arch arch, const std::string & arch_name_override, const char * suffix = nullptr);
 
     llm_arch arch;
     const char * suffix;
+    std::string arch_name_override;
 
     std::string operator()(llm_kv kv) const;
 };

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -372,6 +372,32 @@ llama_context::llama_context(
             LLAMA_LOG_INFO("%s: pipeline parallelism enabled\n", __func__);
         }
 
+        // DFlash: mark context as decoder if it has a target model
+        if (model.arch == LLM_ARCH_DFLASH && params.target_model != nullptr) {
+            dflash_decoder_ctx = true;
+
+            auto & dflash_model = const_cast<llama_model &>(model);
+            dflash_model.tok_embd = params.target_model->tok_embd;
+            dflash_model.output   = params.target_model->output ? params.target_model->output : params.target_model->tok_embd;
+            dflash_model.output_s = params.target_model->output_s;
+
+            // Inherit target-architecture-specific transforms applied around the shared
+            // tok_embd / lm_head. Gemma4 normalizes noise embeddings by sqrt(n_embd) and
+            // applies a final logit softcap; the drafter was trained against those, so
+            // the dflash decoder graph must replicate them. See vLLM PR #41703.
+            if (params.target_model->arch == LLM_ARCH_GEMMA4) {
+                const float n_embd_target = (float) params.target_model->hparams.n_embd;
+                // Match Gemma4 training-time BF16 rounding of sqrt(n_embd).
+                dflash_model.hparams.f_embedding_scale =
+                    ggml_bf16_to_fp32(ggml_fp32_to_bf16(sqrtf(n_embd_target)));
+                dflash_model.hparams.f_final_logit_softcapping =
+                    params.target_model->hparams.f_final_logit_softcapping;
+            } else {
+                dflash_model.hparams.f_embedding_scale = 1.0f;
+                dflash_model.hparams.f_final_logit_softcapping = 0.0f;
+            }
+        }
+
         sched_reserve();
 
         if (!cparams.flash_attn) {
@@ -1254,7 +1280,148 @@ bool llama_context::set_adapter_cvec(
     return res;
 }
 
+//
+// DFlash speculative decoding — extraction pipeline
+//
+
+void llama_context::set_dflash(const llama_model * model) {
+    cparams.dflash_extract_enabled = !!model;
+    if (!cparams.dflash_extract_enabled) {
+        return;
+    }
+
+    sched_need_reserve = true;
+
+    const auto & dflash_hparams = model->hparams;
+
+    dflash.extract_layer_indices.clear();
+    for (const int il : dflash_hparams.dflash_target_layer_ids) {
+        if (il < 0) {
+            break;
+        }
+        dflash.extract_layer_indices.push_back(il);
+    }
+
+    dflash.extract_tensors.resize(dflash.extract_layer_indices.size(), nullptr);
+
+    LLAMA_LOG_INFO("%s: DFlash extraction enabled for %zu layers\n", __func__,
+            dflash.extract_layer_indices.size());
+}
+
+const float * llama_context::get_dflash_target_features() const {
+    GGML_ASSERT(!dflash.target_features.empty() && "DFlash target features not extracted");
+    return dflash.target_features.data();
+}
+
+static void llama_dflash_read_hidden_2d(ggml_tensor * tensor, std::vector<float> & dst, int64_t n_embd, int64_t n_tokens) {
+    GGML_ASSERT(tensor != nullptr);
+    GGML_ASSERT(tensor->type == GGML_TYPE_F32);
+    GGML_ASSERT(tensor->ne[0] == n_embd);
+    GGML_ASSERT(tensor->ne[1] >= n_tokens);
+
+    dst.resize((size_t)n_embd * (size_t)n_tokens);
+
+    const size_t row_bytes = (size_t)n_embd * sizeof(float);
+    for (int64_t token_idx = 0; token_idx < n_tokens; ++token_idx) {
+        const size_t src_offset = (size_t)token_idx * (size_t)tensor->nb[1];
+        float * row = dst.data() + (size_t)token_idx * (size_t)n_embd;
+
+        if (ggml_backend_buffer_is_host(tensor->buffer)) {
+            std::memcpy(row, (const char *)tensor->data + src_offset, row_bytes);
+        } else {
+            ggml_backend_tensor_get(tensor, row, src_offset, row_bytes);
+        }
+    }
+}
+
+void llama_context::set_dflash_accumulated_target_ctx(const float * data, int32_t n_embd, int32_t n_tokens) {
+    GGML_ASSERT(data != nullptr);
+    GGML_ASSERT(n_embd > 0);
+    GGML_ASSERT(n_tokens > 0);
+    auto cross_bucket = [](int32_t n) -> int32_t {
+        if (n <= 16) {
+            return 16;
+        }
+        int32_t bucket = 1;
+        while (bucket < n) {
+            bucket <<= 1;
+        }
+        return bucket;
+    };
+
+    const int32_t bucket = cross_bucket(n_tokens);
+    if (cross.n_enc != bucket) {
+        sched_need_reserve = true;
+    }
+
+    const size_t data_size = (size_t)n_embd * n_tokens;
+    const size_t bucket_size = (size_t)n_embd * bucket;
+    cross.n_embd = n_embd;
+    cross.n_enc  = bucket;
+    cross.n_enc_real = n_tokens;
+    cross.v_embd.assign(bucket_size, 0.0f);
+    std::memcpy(cross.v_embd.data(), data, data_size * sizeof(float));
+
+    if (model.arch == LLM_ARCH_DFLASH && dflash_decoder_ctx) {
+        gf_res_prev->reset();
+    }
+}
+
+void llama_context::extract_dflash_features(const llama_ubatch & ubatch) {
+    const int64_t n_tokens = ubatch.n_tokens;
+    const int64_t n_embd = model.hparams.n_embd;
+    const size_t n_layers = dflash.extract_tensors.size();
+
+    const int64_t n_embd_concat = n_embd * (int64_t)n_layers;
+
+    // APPEND across ubatches WITHIN a single decode call. llama_context::decode()
+    // clears target_features at its start (before the ubatch loop), and each
+    // ubatch's extract appends its features at the current end. Drafter then
+    // reads from offset 0 — the buffer holds exactly the features for the
+    // tokens decoded in this call.
+    //
+    // Pre-fix the buffer was resize()'d per ubatch, dropping every earlier
+    // ubatch's features. For prompts that span multiple ubatches (any prompt
+    // larger than n_ubatch, default 512) the drafter's n_new read would
+    // overflow into adjacent heap → SIGSEGV. Mission m-20260527-103737
+    // post-Gate-C heierchat-streaming crash.
+    const size_t prev_floats = dflash.target_features.size();
+    dflash.target_features.resize(prev_floats + (size_t)(n_embd_concat * n_tokens));
+    float * dest_base = dflash.target_features.data() + prev_floats;
+
+    static thread_local std::vector<float> temp_layer_features;
+
+    LLAMA_LOG_DEBUG("extract_dflash_features: %zu layers, %lld tokens, %lld embd, append-base %zu\n",
+                    n_layers, (long long)n_tokens, (long long)n_embd, prev_floats);
+
+    for (size_t layer_idx = 0; layer_idx < n_layers; ++layer_idx) {
+        ggml_tensor * tensor = dflash.extract_tensors[layer_idx];
+        GGML_ASSERT(tensor != nullptr && "DFlash extraction tensor is null");
+
+        llama_dflash_read_hidden_2d(tensor, temp_layer_features, n_embd, n_tokens);
+
+        for (int64_t token_idx = 0; token_idx < n_tokens; ++token_idx) {
+            const float * src = temp_layer_features.data() + token_idx * n_embd;
+            float * dest = dest_base + token_idx * n_embd_concat + (int64_t)layer_idx * n_embd;
+            std::memcpy(dest, src, (size_t)n_embd * sizeof(float));
+        }
+    }
+}
+
+void llama_context::clear_dflash_target_features() {
+    dflash.target_features.clear();
+}
+
+void llama_context::set_dflash_need_reserve() {
+    sched_need_reserve = true;
+}
+
 llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, llm_graph_type gtype, llama_memory_context_i * mctx, ggml_status & ret) {
+    // DFlash decoder runs through encode path due to no kv-cache, but needs decoder graph type
+    if (model.arch == LLM_ARCH_DFLASH && dflash_decoder_ctx && gtype == LLM_GRAPH_TYPE_ENCODER) {
+        gtype = LLM_GRAPH_TYPE_DECODER;
+    }
+
     if (mctx && !mctx->apply()) {
         LLAMA_LOG_ERROR("%s: failed to apply memory context\n", __func__);
         ret = GGML_STATUS_FAILED;
@@ -1319,6 +1486,11 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         LLAMA_LOG_ERROR("%s: failed to compute graph, compute status: %d\n", __func__, status);
         ret = status;
         return nullptr;
+    }
+
+    // DFlash: Extract intermediate layer features after graph execution
+    if (cparams.dflash_extract_enabled && !dflash.extract_tensors.empty()) {
+        extract_dflash_features(ubatch);
     }
 
     ret = GGML_STATUS_SUCCESS;
@@ -1709,6 +1881,26 @@ int llama_context::decode(const llama_batch & batch_inp) {
     // TODO: this clear of the buffer can easily be forgotten - need something better
     embd_seq.clear();
     output_swaps.clear();
+
+    // DFlash: clear target_features at the start of a decode call ONLY if it
+    // contains the beginning of a prompt (any token with pos == 0). This allows
+    // target_features to accumulate features across consecutive prefill decodes,
+    // which is needed for split-prefill prompts (checkpoints or large batches).
+    // The buffer is cleared at the end of draft() once the features are consumed.
+    if (cparams.dflash_extract_enabled && !dflash.extract_tensors.empty()) {
+        bool has_pos_0 = false;
+        if (batch_inp.pos != nullptr) {
+            for (int32_t i = 0; i < batch_inp.n_tokens; ++i) {
+                if (batch_inp.pos[i] == 0) {
+                    has_pos_0 = true;
+                    break;
+                }
+            }
+        }
+        if (has_pos_0) {
+            dflash.target_features.clear();
+        }
+    }
 
     sched_reserve();
 
@@ -2305,6 +2497,7 @@ llm_graph_params llama_context::graph_params(
         /*.loras       =*/ loras.get(),
         /*.mctx        =*/ mctx,
         /*.cross       =*/ &cross,
+        /*.dflash      =*/ &dflash,
         /*.samplers    =*/ sampling.samplers,
         /*.n_outputs   =*/ n_outputs,
         /*.cb          =*/ graph_get_cb(),
@@ -2347,6 +2540,21 @@ llm_graph_cb llama_context::graph_get_cb() const {
             ggml_format_name(cur, "%s-%d", name, il);
         } else {
             ggml_set_name(cur, name);
+        }
+
+        // DFlash: capture intermediate hidden states tagged "dflash_extract_N"
+        // during graph build so they can be read after graph compute
+        if (cparams.dflash_extract_enabled) {
+            static constexpr const char * prefix = "dflash_extract_";
+            static constexpr size_t prefix_len = 15;
+
+            if (strncmp(name, prefix, prefix_len) == 0) {
+                size_t extract_idx = 0;
+                if (sscanf(name + prefix_len, "%zu", &extract_idx) == 1 && extract_idx < dflash.extract_tensors.size()) {
+                    ggml_set_output(cur);
+                    dflash.extract_tensors[extract_idx] = cur;
+                }
+            }
         }
 
         // norm may be automatically assigned to the backend of the previous layer, increasing data transfer between backends
@@ -3372,6 +3580,7 @@ llama_context_params llama_context_default_params() {
         /*.no_perf                     =*/ true,
         /*.op_offload                  =*/ true,
         /*.swa_full                    =*/ true,
+        /*.target_model                =*/ nullptr,
         /*.kv_unified                  =*/ false,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -244,6 +244,13 @@ public:
 
     bool set_sampler(llama_seq_id seq_id, llama_sampler * sampler);
 
+    // DFlash speculative decoding
+    void set_dflash(const llama_model * model);
+    const float * get_dflash_target_features() const;
+    void set_dflash_accumulated_target_ctx(const float * data, int32_t n_embd, int32_t n_tokens);
+    void clear_dflash_target_features();
+    void set_dflash_need_reserve();
+
 private:
     llm_graph_params graph_params(
                         llm_graph_result * res,
@@ -252,6 +259,8 @@ private:
                           llm_graph_type   gtype) const;
 
     llm_graph_cb graph_get_cb() const;
+
+    void extract_dflash_features(const llama_ubatch & ubatch);
 
     // TODO: read/write lora adapters and cvec
     size_t state_write_data(llama_io_write_i & io);
@@ -272,6 +281,9 @@ private:
     llama_adapter_loras_ptr loras;
 
     llama_cross cross; // TODO: tmp for handling cross-attention - need something better probably
+    mutable llama_dflash dflash;
+
+    bool dflash_decoder_ctx = false;
 
     std::unique_ptr<llama_memory_i> memory;
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -42,6 +42,7 @@ struct llama_cparams {
     bool warmup;             // TODO: remove [TAG_LLAMA_GRAPH_NO_WARMUP]
     bool op_offload;
     bool kv_unified;
+    bool dflash_extract_enabled;  // enable layer extraction for DFlash speculative decoding
     bool pipeline_parallel;
 
     enum llama_context_type ctx_type;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -139,13 +139,13 @@ static ggml_tensor * ggml_mul_mat_aux(
 }
 
 void llm_graph_input_embd::set_input(const llama_ubatch * ubatch) {
-    if (ubatch->token) {
+    if (ubatch->token && tokens) {
         const int64_t n_tokens = ubatch->n_tokens;
 
         ggml_backend_tensor_set(tokens, ubatch->token, 0, n_tokens*ggml_element_size(tokens));
     }
 
-    if (ubatch->embd) {
+    if (ubatch->embd && embd) {
         GGML_ASSERT(n_embd == embd->ne[0]);
 
         const int64_t n_tokens = ubatch->n_tokens;
@@ -437,8 +437,62 @@ void llm_graph_input_cross_embd::set_input(const llama_ubatch * ubatch) {
 
     if (cross_embd && !cross->v_embd.empty()) {
         assert(cross_embd->type == GGML_TYPE_F32);
+        GGML_ASSERT(cross_embd->ne[0] == cross->n_embd);
+        GGML_ASSERT(cross_embd->ne[1] == cross->n_enc);
 
         ggml_backend_tensor_set(cross_embd, cross->v_embd.data(), 0, ggml_nbytes(cross_embd));
+    }
+}
+
+void llm_graph_input_dflash::set_input(const llama_ubatch * ubatch) {
+    GGML_UNUSED(ubatch);
+
+    if (target_hidden && cross && !cross->v_embd.empty()) {
+        GGML_ASSERT(target_hidden->type == GGML_TYPE_F32);
+        ggml_backend_tensor_set(target_hidden, cross->v_embd.data(), 0, ggml_nbytes(target_hidden));
+    }
+
+    const int64_t n_real = cross ? cross->n_enc_real : ctx_len;
+
+    if (pos_ctx && pos_ctx->buffer) {
+        GGML_ASSERT(ggml_backend_buffer_is_host(pos_ctx->buffer));
+        auto * data = (int32_t *) pos_ctx->data;
+        for (int64_t i = 0; i < ctx_len; ++i) {
+            data[i] = i < n_real ? (int32_t)i : 0;
+        }
+    }
+
+    const int64_t n_kv = ctx_len + n_block;
+
+    if (kq_mask && kq_mask->buffer) {
+        GGML_ASSERT(ggml_backend_buffer_is_host(kq_mask->buffer));
+        auto * data = (float *) kq_mask->data;
+        for (int64_t q = 0; q < n_block; ++q) {
+            for (int64_t k = 0; k < n_kv; ++k) {
+                data[q * n_kv + k] = (k >= n_real && k < ctx_len) ? -INFINITY : 0.0f;
+            }
+        }
+    }
+
+    // SWA mask variant: same bucket-padding mask PLUS sliding-window mask between noise
+    // (q at absolute pos n_real+q) and ctx (k at absolute pos k for k<n_real).  Noise→noise
+    // distances are small (<= n_block); ctx→ctx unused here (q is noise only).
+    if (kq_mask_swa && kq_mask_swa->buffer && n_swa > 0) {
+        GGML_ASSERT(ggml_backend_buffer_is_host(kq_mask_swa->buffer));
+        auto * data = (float *) kq_mask_swa->data;
+        for (int64_t q = 0; q < n_block; ++q) {
+            const int64_t q_pos = n_real + q;
+            for (int64_t k = 0; k < n_kv; ++k) {
+                // bucket padding always masked
+                if (k >= n_real && k < ctx_len) {
+                    data[q * n_kv + k] = -INFINITY;
+                    continue;
+                }
+                // determine k's absolute position: ctx region [0..n_real), noise region [ctx_len..ctx_len+n_block)
+                const int64_t k_pos = (k < ctx_len) ? k : (n_real + (k - ctx_len));
+                data[q * n_kv + k] = (q_pos - k_pos >= n_swa) ? -INFINITY : 0.0f;
+            }
+        }
     }
 }
 
@@ -1092,6 +1146,7 @@ llm_graph_context::llm_graph_context(const llm_graph_params & params) :
     loras            (params.loras),
     mctx             (params.mctx),
     cross            (params.cross),
+    dflash           (params.dflash),
     samplers         (params.samplers),
     cb_func          (params.cb),
     res              (params.res),

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -68,12 +68,26 @@ struct llama_cross {
 
     int64_t n_embd = 0;
     int64_t n_enc  = 0;
+    int64_t n_enc_real = 0;
 
     // embeddings data copied to host memory (tmp)
     std::vector<float> v_embd;
 
     // needed to construct the cross-attention mask in the decoder
     std::vector<std::set<llama_seq_id>> seq_ids_enc;
+};
+
+
+// DFlash speculative decoding intermediate results
+struct llama_dflash {
+    std::vector<int> extract_layer_indices;
+    std::vector<float> target_features;
+    std::vector<ggml_tensor *> extract_tensors;
+
+    void clear() {
+        target_features.clear();
+        extract_tensors.clear();
+    }
 };
 
 struct llm_graph_params;
@@ -277,6 +291,27 @@ public:
     ggml_tensor * cross_embd; // F32 [n_embd, n_outputs_enc]
 
     const llama_cross * cross;
+};
+
+class llm_graph_input_dflash : public llm_graph_input_i {
+public:
+    llm_graph_input_dflash(const llama_cross * cross, int64_t ctx_len, int64_t n_block, int64_t n_swa = 0)
+        : cross(cross), ctx_len(ctx_len), n_block(n_block), n_swa(n_swa) {}
+    virtual ~llm_graph_input_dflash() = default;
+
+    void set_input(const llama_ubatch * ubatch) override;
+
+    ggml_tensor * target_hidden    = nullptr; // F32 [n_target_features, ctx_len]
+    ggml_tensor * pos_ctx          = nullptr; // I32 [ctx_len]
+    ggml_tensor * kq_mask          = nullptr; // F32 [ctx_len + n_block, n_block, 1, 1] — full attention mask
+    ggml_tensor * kq_mask_cnv      = nullptr;
+    ggml_tensor * kq_mask_swa      = nullptr; // F32, same shape — SWA-windowed variant for SWA layers
+    ggml_tensor * kq_mask_swa_cnv  = nullptr;
+
+    const llama_cross * cross;
+    int64_t ctx_len;
+    int64_t n_block;
+    int64_t n_swa;  // sliding window size (0 = no SWA layers)
 };
 
 class llm_graph_input_attn_no_cache : public llm_graph_input_i {
@@ -602,6 +637,7 @@ struct llm_graph_params {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
+    const llama_dflash           * dflash = nullptr;
 
     std::map<llama_seq_id, llama_sampler *> samplers;
 
@@ -819,6 +855,7 @@ struct llm_graph_context {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
+    const llama_dflash           * dflash = nullptr;
 
     std::map<llama_seq_id, llama_sampler *> samplers;
 

--- a/src/llama-hparams.h
+++ b/src/llama-hparams.h
@@ -221,6 +221,12 @@ struct llama_hparams {
     // qwen3vl deepstack
     uint32_t n_deepstack_layers = 0;
 
+    // DFlash draft model
+    std::array<int, 16> dflash_target_layer_ids = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+    uint32_t dflash_block_size     = 16;
+    uint32_t dflash_mask_token_id  = 0;
+    uint32_t dflash_n_target_features = 0;
+
     // gemma4 per-layer embedding
     uint32_t n_embd_per_layer = 0;
 

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -392,6 +392,7 @@ namespace GGUFMeta {
         return get_arr(llm_kv(kid), result, required);
     }
 
+    template bool llama_model_loader::get_arr<std::array<int, 16>>(enum llm_kv kid, std::array<int, 16> & result, bool required);
     template bool llama_model_loader::get_arr<std::vector<std::string>>(enum llm_kv kid, std::vector<std::string> & result, bool required);
 
     template<typename T>
@@ -503,6 +504,7 @@ namespace GGUFMeta {
 
     // TODO: this is not very clever - figure out something better
     template bool llama_model_loader::get_key_or_arr<std::array<int,      4>>  (enum llm_kv kid, std::array<int,      4>   & result, uint32_t n, bool required);
+    template bool llama_model_loader::get_key_or_arr<std::array<int,      5>>  (enum llm_kv kid, std::array<int,      5>   & result, uint32_t n, bool required);
     template bool llama_model_loader::get_key_or_arr<std::array<uint32_t, 512>>(enum llm_kv kid, std::array<uint32_t, 512> & result, uint32_t n, bool required);
     template bool llama_model_loader::get_key_or_arr<std::array<float,    512>>(enum llm_kv kid, std::array<float,    512> & result, uint32_t n, bool required);
 
@@ -549,7 +551,7 @@ llama_model_loader::llama_model_loader(
         }
 
         get_key(llm_kv(LLM_KV_GENERAL_ARCHITECTURE), arch_name, false);
-        llm_kv = LLM_KV(llm_arch_from_string(arch_name));
+        llm_kv = LLM_KV(llm_arch_from_string(arch_name), arch_name);
 
         files.emplace_back(new llama_file(fname.c_str(), "rb", use_direct_io));
         contexts.emplace_back(ctx);
@@ -675,7 +677,7 @@ llama_model_loader::llama_model_loader(
         }
 
         get_key(llm_kv(LLM_KV_GENERAL_ARCHITECTURE), arch_name, false);
-        llm_kv = LLM_KV(llm_arch_from_string(arch_name));
+        llm_kv = LLM_KV(llm_arch_from_string(arch_name), arch_name);
 
         files.emplace_back(new llama_file(file));
         contexts.emplace_back(ctx);
@@ -693,7 +695,7 @@ llama_model_loader::llama_model_loader(
         }
     } else {
         get_key(llm_kv(LLM_KV_GENERAL_ARCHITECTURE), arch_name, false);
-        llm_kv = LLM_KV(llm_arch_from_string(arch_name));
+        llm_kv = LLM_KV(llm_arch_from_string(arch_name), arch_name);
     }
 
     n_kv      = gguf_get_n_kv(metadata);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -287,6 +287,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
             return new llama_model_mistral3(params);
         case LLM_ARCH_MIMO2:
             return new llama_model_mimo2(params);
+        case LLM_ARCH_DFLASH:
+            return new llama_model_dflash(params);
         case LLM_ARCH_KIMI_LINEAR:
             return new llama_model_kimi_linear(params);
         case LLM_ARCH_STEP35:
@@ -2244,6 +2246,25 @@ int32_t llama_model_n_head_kv(const llama_model * model) {
     return model->hparams.n_head_kv();
 }
 
+int32_t llama_model_dflash_block_size(const llama_model * model) {
+    return (int32_t) model->hparams.dflash_block_size;
+}
+
+int32_t llama_model_dflash_mask_token_id(const llama_model * model) {
+    return (int32_t) model->hparams.dflash_mask_token_id;
+}
+
+int32_t llama_model_dflash_n_target_layers(const llama_model * model) {
+    int32_t n = 0;
+    for (const int il : model->hparams.dflash_target_layer_ids) {
+        if (il < 0) {
+            break;
+        }
+        n++;
+    }
+    return n;
+}
+
 int32_t llama_model_n_swa(const llama_model * model) {
     return model->hparams.n_swa;
 }
@@ -2410,6 +2431,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
         case LLM_ARCH_STEP35:
         case LLM_ARCH_TALKIE:
         case LLM_ARCH_MELLUM:
+        case LLM_ARCH_DFLASH:
             return LLAMA_ROPE_TYPE_NEOX;
 
         case LLM_ARCH_QWEN2VL:

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -532,6 +532,10 @@ struct llama_model {
     std::vector<std::string> classifier_labels;
 
     struct ggml_tensor * tok_embd   = nullptr;
+    struct ggml_tensor * fc = nullptr;
+    struct ggml_tensor * dflash_hidden_norm = nullptr;
+    struct ggml_tensor * target_tok_embd = nullptr;
+    struct ggml_tensor * target_output = nullptr;
     struct ggml_tensor * type_embd  = nullptr;
     struct ggml_tensor * pos_embd   = nullptr;
     struct ggml_tensor * tok_norm   = nullptr;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -579,3 +579,33 @@ const char * llama_print_system_info(void) {
     return s.c_str();
 }
 
+//
+// DFlash speculative decoding API
+//
+
+void llama_set_dflash(
+        struct llama_context * ctx,
+        const struct llama_model * model) {
+    ctx->set_dflash(model);
+}
+
+const float * llama_get_dflash_target_features(struct llama_context * ctx) {
+    return ctx->get_dflash_target_features();
+}
+
+void llama_clear_dflash_target_features(struct llama_context * ctx) {
+    ctx->clear_dflash_target_features();
+}
+
+void llama_set_dflash_accumulated_target_ctx(
+        struct llama_context * ctx,
+               const float * data,
+                   int32_t   n_embd,
+                   int32_t   n_tokens) {
+    ctx->set_dflash_accumulated_target_ctx(data, n_embd, n_tokens);
+}
+
+void llama_set_dflash_need_reserve(struct llama_context * ctx) {
+    ctx->set_dflash_need_reserve();
+}
+

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -1,0 +1,301 @@
+#include "models.h"
+
+// ==========================================================================
+// DFlash encoder graph — fuses extracted target features into draft token embedding
+// ==========================================================================
+
+ggml_tensor * llm_build_dflash_encode::build_inp_embd() const {
+    int64_t n_target_layer_ids = 0;
+    for (int i = 0; i < 16; i++) {
+        if (hparams.dflash_target_layer_ids[i] != -1) n_target_layer_ids++;
+        else break;
+    }
+    const int64_t n_embd_target_features = n_target_layer_ids * n_embd;
+
+    auto inp_target = std::make_unique<llm_graph_input_embd>(n_embd_target_features);
+    inp_target->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd_target_features, n_tokens);
+    ggml_set_input(inp_target->embd);
+
+    ggml_tensor * cur = inp_target->embd;
+    cb(cur, "inp_embd", -1);
+    res->add_input(std::move(inp_target));
+    return cur;
+}
+
+llm_build_dflash_encode::llm_build_dflash_encode(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+    ggml_tensor * cur = build_inp_embd();
+    cur = build_lora_mm(model.fc, cur);
+    cb(cur, "fc_out", -1);
+    cur = build_norm(cur, model.dflash_hidden_norm, NULL, LLM_NORM_RMS, -1);
+    cb(cur, "hidden_norm_out", -1);
+    res->t_embd = cur;
+    ggml_build_forward_expand(gf, cur);
+}
+
+// ==========================================================================
+// DFlash decoder graph — cross-attention draft token generation
+// ==========================================================================
+
+llm_build_dflash_decode::llm_build_dflash_decode(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+    // env-gated experiment: re-apply layer.attn_norm to fused_target before each layer's wk/wv
+    // hypothesis: drafter trained with per-layer ctx renorm; without it K_ctx/V_ctx are wrong-scaled past layer 0
+    static const bool dflash_per_layer_renorm = []() {
+        const char * e = std::getenv("LLAMA_DFLASH_PER_LAYER_RENORM");
+        return e && e[0] != '\0' && e[0] != '0';
+    }();
+
+    const int64_t n_embd_head = hparams.n_embd_head_v();
+    GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
+
+    const int64_t n_target_features = model.hparams.dflash_n_target_features != 0 ? model.hparams.dflash_n_target_features : n_embd * llama_model_dflash_n_target_layers(&model);
+    const int64_t ctx_len = (cross && !cross->v_embd.empty()) ? cross->n_enc : n_ctx;
+    const int64_t n_kv_total = ctx_len + n_tokens;
+
+    const bool dflash_has_swa = hparams.is_swa_any() && hparams.n_swa > 0;
+    auto inp_dflash = std::make_unique<llm_graph_input_dflash>(
+        cross, ctx_len, n_tokens, dflash_has_swa ? (int64_t)hparams.n_swa : 0);
+    inp_dflash->target_hidden = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_target_features, ctx_len);
+    ggml_set_input(inp_dflash->target_hidden);
+    cb(inp_dflash->target_hidden, "dflash_target_hidden", -1);
+
+    inp_dflash->pos_ctx = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, ctx_len);
+    ggml_set_input(inp_dflash->pos_ctx);
+    cb(inp_dflash->pos_ctx, "dflash_pos_ctx", -1);
+
+    inp_dflash->kq_mask = ggml_new_tensor_4d(ctx0, GGML_TYPE_F32, n_kv_total, n_tokens, 1, 1);
+    ggml_set_input(inp_dflash->kq_mask);
+    inp_dflash->kq_mask_cnv = cparams.flash_attn ? ggml_cast(ctx0, inp_dflash->kq_mask, GGML_TYPE_F16) : inp_dflash->kq_mask;
+
+    if (dflash_has_swa) {
+        inp_dflash->kq_mask_swa = ggml_new_tensor_4d(ctx0, GGML_TYPE_F32, n_kv_total, n_tokens, 1, 1);
+        ggml_set_input(inp_dflash->kq_mask_swa);
+        inp_dflash->kq_mask_swa_cnv = cparams.flash_attn ? ggml_cast(ctx0, inp_dflash->kq_mask_swa, GGML_TYPE_F16) : inp_dflash->kq_mask_swa;
+    }
+
+    ggml_tensor * kq_mask       = inp_dflash->kq_mask_cnv;
+    ggml_tensor * kq_mask_swa   = inp_dflash->kq_mask_swa_cnv;
+    ggml_tensor * pos_ctx       = inp_dflash->pos_ctx;
+    ggml_tensor * target_hidden = inp_dflash->target_hidden;
+
+    res->add_input(std::move(inp_dflash));
+
+    GGML_ASSERT(model.tok_embd != nullptr && "DFlash decoder requires target model's tok_embd");
+    // build_inp_embd auto-applies hparams.f_embedding_scale when non-zero — this is how
+    // we inherit Gemma4's sqrt(n_embd) noise embedding normalization via the cross-binding
+    // in llama-context.cpp. See vLLM PR #41703 for the architectural rationale.
+    ggml_tensor * inpL = build_inp_embd(model.tok_embd);
+    cb(inpL, "inp_noise_embd", -1);
+
+    ggml_tensor * inp_pos = build_inp_pos();
+
+    ggml_tensor * fused_target = build_lora_mm(model.fc, target_hidden);
+    fused_target = build_norm(fused_target, model.dflash_hidden_norm, NULL, LLM_NORM_RMS, -1);
+    cb(fused_target, "fused_target", -1);
+
+    const float kq_scale = 1.0f/sqrtf(float(n_embd_head));
+
+    for (int il = 0; il < n_layer; ++il) {
+        const auto & layer = model.layers[il];
+        ggml_tensor * inpSA = inpL;
+
+        ggml_tensor * cur = build_norm(inpL, layer.attn_norm, NULL, LLM_NORM_RMS, il);
+        cb(cur, "attn_norm", il);
+
+        ggml_tensor * ctx_src = fused_target;
+        if (dflash_per_layer_renorm) {
+            ctx_src = build_norm(fused_target, layer.attn_norm, NULL, LLM_NORM_RMS, il);
+            cb(ctx_src, "ctx_attn_norm", il);
+        }
+
+        // Q from noise only
+        ggml_tensor * Qcur = build_lora_mm(layer.wq, cur);
+        if (layer.wq_b) { Qcur = ggml_add(ctx0, Qcur, layer.wq_b); }
+        Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
+        Qcur = build_norm(Qcur, layer.attn_q_norm, NULL, LLM_NORM_RMS, il);
+        Qcur = ggml_rope_ext(
+                ctx0, Qcur, inp_pos, nullptr,
+                n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                ext_factor, attn_factor, beta_fast, beta_slow);
+        cb(Qcur, "Qcur", il);
+
+        ggml_tensor * K_noise = build_lora_mm(layer.wk, cur);
+        if (layer.wk_b) {
+            K_noise = ggml_add(ctx0, K_noise, layer.wk_b);
+        }
+        K_noise = ggml_reshape_3d(ctx0, K_noise, n_embd_head, n_head_kv, n_tokens);
+        K_noise = build_norm(K_noise, layer.attn_k_norm, NULL, LLM_NORM_RMS, il);
+        K_noise = ggml_rope_ext(
+                ctx0, K_noise, inp_pos, nullptr,
+                n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                ext_factor, attn_factor, beta_fast, beta_slow);
+        cb(K_noise, "Kcur_noise", il);
+
+        ggml_tensor * K_ctx = build_lora_mm(layer.wk, ctx_src);
+        if (layer.wk_b) { K_ctx = ggml_add(ctx0, K_ctx, layer.wk_b); }
+        K_ctx = ggml_reshape_3d(ctx0, K_ctx, n_embd_head, n_head_kv, ctx_len);
+        K_ctx = build_norm(K_ctx, layer.attn_k_norm, NULL, LLM_NORM_RMS, il);
+        K_ctx = ggml_rope_ext(
+                ctx0, K_ctx, pos_ctx, nullptr,
+                n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                ext_factor, attn_factor, beta_fast, beta_slow);
+        cb(K_ctx, "Kcur_ctx", il);
+
+        ggml_tensor * V_noise = build_lora_mm(layer.wv, cur);
+        if (layer.wv_b) {
+            V_noise = ggml_add(ctx0, V_noise, layer.wv_b);
+        }
+        V_noise = ggml_reshape_3d(ctx0, V_noise, n_embd_head, n_head_kv, n_tokens);
+        cb(V_noise, "Vcur_noise", il);
+
+        ggml_tensor * V_ctx = build_lora_mm(layer.wv, ctx_src);
+        if (layer.wv_b) { V_ctx = ggml_add(ctx0, V_ctx, layer.wv_b); }
+        V_ctx = ggml_reshape_3d(ctx0, V_ctx, n_embd_head, n_head_kv, ctx_len);
+        cb(V_ctx, "Vcur_ctx", il);
+
+        ggml_tensor * Kcur = ggml_concat(ctx0, K_ctx, K_noise, 2);
+        ggml_tensor * Vcur = ggml_concat(ctx0, V_ctx, V_noise, 2);
+        cb(Kcur, "Kcur", il);
+        cb(Vcur, "Vcur", il);
+
+        ggml_build_forward_expand(gf, Qcur);
+        ggml_build_forward_expand(gf, Kcur);
+        ggml_build_forward_expand(gf, Vcur);
+
+        // Per-layer mask selection: SWA layers use the windowed mask (kq_mask_swa) so noise
+        // tokens only attend to ctx tokens within the trained sliding window.  Dense layers
+        // use the full mask.  At ctx_len <= n_swa this is a no-op (no key is windowed out).
+        ggml_tensor * layer_kq_mask = (kq_mask_swa && hparams.is_swa(il)) ? kq_mask_swa : kq_mask;
+        cur = build_attn_mha(Qcur, Kcur, Vcur, nullptr, layer_kq_mask, nullptr, nullptr, kq_scale, il);
+        cb(cur, "kqv_out", il);
+
+        cur = build_lora_mm(layer.wo, cur);
+        if (layer.wo_b) { cur = ggml_add(ctx0, cur, layer.wo_b); }
+        cur = ggml_add(ctx0, cur, inpSA);
+        cb(cur, "attn_residual", il);
+
+        ggml_tensor * ffn_inp = cur;
+        cur = build_norm(cur, layer.attn_post_norm, NULL, LLM_NORM_RMS, il);
+        cb(cur, "attn_post_norm", il);
+
+        cur = build_ffn(cur,
+                layer.ffn_up,   NULL, NULL,
+                layer.ffn_gate, NULL, NULL,
+                layer.ffn_down, NULL, NULL,
+                NULL,
+                LLM_FFN_SILU, LLM_FFN_PAR, il);
+        cb(cur, "ffn_out", il);
+
+        cur = ggml_add(ctx0, cur, ffn_inp);
+        cb(cur, "l_out", il);
+
+        inpL = cur;
+    }
+
+    ggml_tensor * cur = inpL;
+    cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
+    cb(cur, "result_norm", -1);
+
+    res->t_embd = cur;
+
+    if (model.output) {
+        cur = build_lora_mm(model.output, cur, model.output_s);
+
+        // Apply target-architecture-specific final logit softcap (Gemma4: 30.0).
+        // Monotonic transform, so does not change argmax for greedy sampling, but
+        // matches the distribution the drafter was trained against. See vLLM PR #41703.
+        if (hparams.f_final_logit_softcapping != 0.0f) {
+            cur = ggml_scale(ctx0, cur, 1.0f / hparams.f_final_logit_softcapping);
+            cur = ggml_tanh(ctx0, cur);
+            cur = ggml_scale(ctx0, cur, hparams.f_final_logit_softcapping);
+        }
+
+        cb(cur, "result_output", -1);
+        res->t_logits = cur;
+    }
+
+    ggml_build_forward_expand(gf, cur);
+}
+
+// ==========================================================================
+// DFlash model class — load_arch_hparams, load_arch_tensors, build_arch_graph
+// ==========================================================================
+
+void llama_model_dflash::load_arch_hparams(llama_model_loader & ml) {
+    ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+    ml.get_key(LLM_KV_DFLASH_BLOCK_SIZE, hparams.dflash_block_size, false);
+    ml.get_key(LLM_KV_DFLASH_MASK_TOKEN_ID, hparams.dflash_mask_token_id, false);
+    ml.get_key(LLM_KV_DFLASH_N_TARGET_FEATURES, hparams.dflash_n_target_features, false);
+    if (!ml.get_arr(LLM_KV_DFLASH_TARGET_LAYER_IDS, hparams.dflash_target_layer_ids, true)) {
+        throw std::runtime_error("missing DFlash target_layer_ids");
+    }
+
+    // Sliding Window Attention: drafter GGUF may carry per-layer sliding_window_pattern
+    // (e.g. Anbeeld Gemma4 drafter: [T,T,T,T,F] with sliding_window=2048).  Latent at small
+    // ctx_window (<=2048) but required for correctness once ctx grows past the window.
+    if (ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false) && hparams.n_swa > 0) {
+        hparams.swa_type = LLAMA_SWA_TYPE_STANDARD;
+        // Re-use std::array<int,16> (already template-instantiated by dflash_target_layer_ids)
+        // to receive the BOOL/INT array.  Filled with 0 by default so unset slots are dense.
+        std::array<int, 16> pattern{};
+        if (ml.get_arr(LLM_KV_ATTENTION_SLIDING_WINDOW_PATTERN, pattern, false)) {
+            const uint32_t n = std::min<uint32_t>(pattern.size(), hparams.n_layer);
+            for (uint32_t il = 0; il < n; ++il) {
+                hparams.is_swa_impl[il] = pattern[il] != 0 ? 1u : 0u;
+            }
+        } else {
+            // No per-layer pattern: assume all layers are SWA.
+            for (uint32_t il = 0; il < hparams.n_layer; ++il) {
+                hparams.is_swa_impl[il] = 1u;
+            }
+        }
+    }
+}
+
+void llama_model_dflash::load_arch_tensors(llama_model_loader & ml) {
+    LLAMA_LOAD_LOCALS;
+
+    int n_target_layer_ids = 0;
+    for (int i = 0; i < 16; i++) {
+        if (hparams.dflash_target_layer_ids[i] != -1) n_target_layer_ids++;
+        else break;
+    }
+
+    const int64_t n_embd_target_features = hparams.dflash_n_target_features != 0 ? hparams.dflash_n_target_features : n_embd * n_target_layer_ids;
+
+    // Feature fusion layer: concatenated target features -> hidden state
+    fc = create_tensor(tn(LLM_TENSOR_DFLASH_FC, "weight"), {n_embd_target_features, n_embd}, 0);
+    dflash_hidden_norm = create_tensor(tn(LLM_TENSOR_DFLASH_HIDDEN_NORM, "weight"), {n_embd}, 0);
+
+    // Token embeddings and output — shared with target model at runtime
+    tok_embd    = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD,  "weight"), {n_embd, n_vocab}, TENSOR_NOT_REQUIRED);
+    output      = create_tensor(tn(LLM_TENSOR_OUTPUT,       "weight"), {n_embd, n_vocab}, TENSOR_NOT_REQUIRED);
+    output_norm = create_tensor(tn(LLM_TENSOR_OUTPUT_NORM,  "weight"), {n_embd}, 0);
+
+    // Layers for draft generation
+    for (uint32_t il = 0; il < hparams.n_layer; ++il) {
+        auto & layer = layers[il];
+        
+        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", il), {n_embd}, 0);
+        layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q, "weight", il), {n_embd, n_embd_head_k * n_head}, 0);
+        layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K, "weight", il), {n_embd, n_embd_k_gqa}, 0);
+        layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V, "weight", il), {n_embd, n_embd_v_gqa}, 0);
+        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", il), {n_embd_head_k * n_head, n_embd}, 0);
+        
+        layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", il), {n_embd_head_k}, TENSOR_NOT_REQUIRED);
+        layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", il), {n_embd_head_k}, TENSOR_NOT_REQUIRED);
+
+        layer.attn_post_norm = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM, "weight", il), {n_embd}, TENSOR_NOT_REQUIRED);
+        layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", il), {n_embd, (int64_t)hparams.n_ff(il)}, TENSOR_NOT_REQUIRED);
+        layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", il), {n_embd, (int64_t)hparams.n_ff(il)}, TENSOR_NOT_REQUIRED);
+        layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", il), {(int64_t)hparams.n_ff(il), n_embd}, TENSOR_NOT_REQUIRED);
+    }
+
+    ml.done_getting_tensors();
+}
+
+std::unique_ptr<llm_graph_context> llama_model_dflash::build_arch_graph(const llm_graph_params & params) const {
+    if (params.dflash && params.cross && !params.cross->v_embd.empty()) {
+        return std::make_unique<llm_build_dflash_decode>(*this, params);
+    }
+    return std::make_unique<llm_build_dflash_encode>(*this, params);
+}

--- a/src/models/gemma4.cpp
+++ b/src/models/gemma4.cpp
@@ -177,7 +177,10 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
     inpL = build_inp_embd(model.tok_embd);
 
     // important: do not normalize weights for raw embeddings input (i.e. encoded image emdeddings)
-    inpL = ggml_scale(ctx0, inpL, ubatch.token ? sqrtf(n_embd) : 1.0f);
+    // Match Gemma4 training-time BF16 rounding before DFlash hidden capture.
+    inpL = ggml_cast(ctx0, inpL, GGML_TYPE_BF16);
+    inpL = ggml_cast(ctx0, inpL, GGML_TYPE_F32);
+    inpL = ggml_scale(ctx0, inpL, ubatch.token ? ggml_bf16_to_fp32(ggml_fp32_to_bf16(sqrtf(n_embd))) : 1.0f);
     cb(inpL, "inp_scaled", -1);
 
     // inp_pos - contains the positions
@@ -197,7 +200,34 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
         inp_per_layer = project_per_layer_inputs(inpL, inp_per_layer);
     }
 
+    // DFlash extraction mode selector — runs once per process.
+    // - "late"     (default): extract after l_out (full layer output incl per_layer_embd + out_scale + cvec)
+    // - "early":              extract after FFN residual, before per_layer_embd processing
+    // - "upstream":           extract inpL at start of layer iteration (matches upstream PR #22105 +1-shift convention)
+    enum dflash_extract_mode { DFLASH_EXTRACT_LATE, DFLASH_EXTRACT_EARLY, DFLASH_EXTRACT_UPSTREAM };
+    static const int dflash_mode = []() {
+        const char * e = std::getenv("LLAMA_DFLASH_EXTRACT");
+        if (!e) return (int)DFLASH_EXTRACT_LATE;
+        const std::string s(e);
+        if (s == "early")    return (int)DFLASH_EXTRACT_EARLY;
+        if (s == "upstream") return (int)DFLASH_EXTRACT_UPSTREAM;
+        return (int)DFLASH_EXTRACT_LATE;
+    }();
+
     for (int il = 0; il < n_layer; ++il) {
+        // DFlash upstream-convention extraction: tag inpL at layer start (pre-attn_norm).
+        // Matches upstream PR #22105's `cb(inpL, dflash_extract_N, il)` convention, where
+        // the converter writes target_layer_ids with a +1 shift so inpL[il] = HF hidden_states[il].
+        if (dflash_mode == DFLASH_EXTRACT_UPSTREAM && dflash && !dflash->extract_layer_indices.empty()) {
+            for (size_t i = 0; i < dflash->extract_layer_indices.size(); ++i) {
+                if (dflash->extract_layer_indices[i] == il) {
+                    const std::string name = "dflash_extract_" + std::to_string(i);
+                    cb(inpL, name.c_str(), il);
+                    break;
+                }
+            }
+        }
+
         const int64_t n_embd_head = hparams.n_embd_head_k(il);
         GGML_ASSERT(n_embd_head == hparams.n_embd_head_v(il));
 
@@ -206,6 +236,7 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
 
         const float freq_base_l  = model.get_rope_freq_base(cparams, il);
         const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
+
         const int   n_rot_l      = hparams.n_rot(il);
 
         // norm
@@ -309,8 +340,11 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
             cb(cur_moe, "ffn_norm_2", il);
 
             // custom MoE logits calculation (router operates on attn_out, not cur)
-            ggml_tensor * tmp = ggml_rms_norm(ctx0, attn_out, hparams.f_norm_rms_eps);
-            tmp = ggml_scale(ctx0, tmp, 1.0f / sqrtf((float) n_embd));
+            // Match Gemma4 router BF16 rounding used by the DFlash reference fork.
+            ggml_tensor * tmp = ggml_cast(ctx0, attn_out, GGML_TYPE_BF16);
+            tmp = ggml_cast(ctx0, tmp, GGML_TYPE_F32);
+            tmp = ggml_rms_norm(ctx0, tmp, hparams.f_norm_rms_eps);
+            tmp = ggml_scale(ctx0, tmp, 1.0f / ggml_bf16_to_fp32(ggml_fp32_to_bf16(sqrtf((float) n_embd))));
             tmp = ggml_mul(ctx0, tmp, model.layers[il].ffn_gate_inp_s);
             ggml_tensor * logits = build_lora_mm(model.layers[il].ffn_gate_inp, tmp); // [n_expert, n_tokens]
             cb(logits, "ffn_moe_logits", il);
@@ -359,6 +393,18 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
         // residual connection
         cur = ggml_add(ctx0, cur, attn_out);
 
+        // DFlash early extraction (LLAMA_DFLASH_EXTRACT=early): tag here, after FFN+attn
+        // residual, before per_layer_embd processing and out_scale.
+        if (dflash_mode == DFLASH_EXTRACT_EARLY && dflash && !dflash->extract_layer_indices.empty()) {
+            for (size_t i = 0; i < dflash->extract_layer_indices.size(); ++i) {
+                if (dflash->extract_layer_indices[i] == il) {
+                    const std::string name = "dflash_extract_" + std::to_string(i);
+                    cb(cur, name.c_str(), il);
+                    break;
+                }
+            }
+        }
+
         // per-layer embedding
         if (inp_per_layer) {
             ggml_tensor * pe_in = cur;
@@ -391,6 +437,18 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
 
         cur = build_cvec(cur, il);
         cb(cur, "l_out", il);
+
+        // DFlash default (late) extraction point (after l_out — full layer output incl
+        // per_layer_embd + out_scale + cvec). Skipped for other modes (tagged elsewhere).
+        if (dflash_mode == DFLASH_EXTRACT_LATE && dflash && !dflash->extract_layer_indices.empty()) {
+            for (size_t i = 0; i < dflash->extract_layer_indices.size(); ++i) {
+                if (dflash->extract_layer_indices[i] == il) {
+                    const std::string name = "dflash_extract_" + std::to_string(i);
+                    cb(cur, name.c_str(), il);
+                    break;
+                }
+            }
+        }
 
         // input for next layer
         inpL = cur;
@@ -443,7 +501,9 @@ ggml_tensor * llama_model_gemma4::graph::build_inp_per_layer() {
 
         inp_per_layer = ggml_get_rows  (ctx0, model.per_layer_tok_embd, inp->tokens);
         inp_per_layer = ggml_reshape_3d(ctx0, inp_per_layer, n_embd_per_layer, n_layer, n_tokens);
-        inp_per_layer = ggml_scale     (ctx0, inp_per_layer, tok_embd_scale);
+        inp_per_layer = ggml_cast      (ctx0, inp_per_layer, GGML_TYPE_BF16);
+        inp_per_layer = ggml_cast      (ctx0, inp_per_layer, GGML_TYPE_F32);
+        inp_per_layer = ggml_scale     (ctx0, inp_per_layer, ggml_bf16_to_fp32(ggml_fp32_to_bf16(tok_embd_scale)));
         cb(inp_per_layer, "inp_per_layer_selected", -1);
 
         res->add_input(std::move(inp));

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -221,6 +221,17 @@ llama_model_llama::graph<embed>::graph(const llama_model & model, const llm_grap
         cur = build_cvec(cur, il);
         cb(cur, "l_out", il);
 
+        // DFlash target layer ids refer to post-layer hidden states.
+        if (dflash && !dflash->extract_layer_indices.empty()) {
+            for (size_t i = 0; i < dflash->extract_layer_indices.size(); ++i) {
+                if (dflash->extract_layer_indices[i] == il) {
+                    const std::string name = "dflash_extract_" + std::to_string(i);
+                    cb(cur, name.c_str(), il);
+                    break;
+                }
+            }
+        }
+
         // input for next layer
         inpL = cur;
     }

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -554,6 +554,24 @@ struct llama_model_qwen3moe : public llama_model_base {
 };
 
 
+struct llama_model_dflash : public llama_model_base {
+    llama_model_dflash(const struct llama_model_params & params) : llama_model_base(params) {}
+    void load_arch_hparams(llama_model_loader & ml) override;
+    void load_arch_tensors(llama_model_loader & ml) override;
+
+    std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
+};
+
+struct llm_build_dflash_encode : public llm_graph_context {
+    llm_build_dflash_encode(const llama_model & model, const llm_graph_params & params);
+private:
+    ggml_tensor * build_inp_embd() const;
+};
+
+struct llm_build_dflash_decode : public llm_graph_context {
+    llm_build_dflash_decode(const llama_model & model, const llm_graph_params & params);
+};
+
 struct llama_model_qwen3vl : public llama_model_base {
     llama_model_qwen3vl(const struct llama_model_params & params) : llama_model_base(params) {}
     void load_arch_hparams(llama_model_loader & ml) override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,6 +192,8 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     # llama_build_and_test(test-double-float.cpp) # SLOW
 
     llama_build_and_test(test-llama-archs.cpp)
+
+    llama_build_and_test(test-dflash.cpp)
 endif()
 
 llama_build_and_test(test-chat-peg-parser.cpp peg-parser/simple-tokenize.cpp)

--- a/tests/test-dflash.cpp
+++ b/tests/test-dflash.cpp
@@ -1,0 +1,221 @@
+#include "common.h"
+#include "log.h"
+#include "ggml.h"
+#include "llama.h"
+#include "llama-cpp.h"
+
+// TODO: replace with #include "llama-ext.h" in the future
+#include "../src/llama-arch.h"
+#include "../src/llama-graph.h"
+#include "../src/llama-hparams.h"
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+//
+// Test 1: DFlash arch name lookup and not UNKNOWN
+//
+static void test_dflash_arch_registered() {
+    const char * name = llm_arch_name(LLM_ARCH_DFLASH);
+    GGML_ASSERT(name != nullptr);
+    GGML_ASSERT(std::string(name) == "dflash");
+    GGML_ASSERT(LLM_ARCH_DFLASH != LLM_ARCH_UNKNOWN);
+    LOG_INF("test_dflash_arch_registered: PASS\n");
+}
+
+//
+// Test 2: DFlash tensor info lookups
+//
+static void test_dflash_tensor_infos() {
+    {
+        const auto & info = llm_tensor_info_for(LLM_TENSOR_DFLASH_FC);
+        GGML_ASSERT(info.layer == LLM_TENSOR_LAYER_OUTPUT);
+        GGML_ASSERT(info.op == GGML_OP_MUL_MAT);
+    }
+    {
+        const auto & info = llm_tensor_info_for(LLM_TENSOR_DFLASH_HIDDEN_NORM);
+        GGML_ASSERT(info.layer == LLM_TENSOR_LAYER_OUTPUT);
+        GGML_ASSERT(info.op == GGML_OP_MUL);
+    }
+    LOG_INF("test_dflash_tensor_infos: PASS\n");
+}
+
+//
+// Test 3: llama_hparams DFlash defaults
+//
+static void test_dflash_hparams_defaults() {
+    llama_hparams hparams;
+    for (int i = 0; i < 16; i++) {
+        GGML_ASSERT(hparams.dflash_target_layer_ids[i] == -1);
+    }
+    GGML_ASSERT(hparams.dflash_block_size == 16);
+    GGML_ASSERT(hparams.dflash_mask_token_id == 0);
+    LOG_INF("test_dflash_hparams_defaults: PASS\n");
+}
+
+//
+// Test 4: llama_dflash struct lifecycle
+//
+static void test_dflash_struct() {
+    llama_dflash dflash;
+    GGML_ASSERT(dflash.extract_layer_indices.empty());
+    GGML_ASSERT(dflash.target_features.empty());
+    GGML_ASSERT(dflash.extract_tensors.empty());
+
+    dflash.extract_layer_indices = {0, 4, 8, 12, 16};
+    GGML_ASSERT(dflash.extract_layer_indices.size() == 5);
+    GGML_ASSERT(dflash.extract_layer_indices[2] == 8);
+
+    dflash.target_features = {0.1f, 0.2f};
+    dflash.extract_tensors.resize(2, nullptr);
+    dflash.clear();
+    GGML_ASSERT(dflash.target_features.empty());
+    GGML_ASSERT(dflash.extract_tensors.empty());
+    LOG_INF("test_dflash_struct: PASS\n");
+}
+
+//
+// Test 5: llm_graph_params dflash pointer wiring
+//
+static void test_dflash_graph_params() {
+    llama_dflash dflash;
+
+    // Default-constructed params have null dflash
+    {
+        llm_graph_params params;
+        GGML_ASSERT(params.dflash == nullptr);
+    }
+
+    // After setting, pointer is reachable
+    dflash.extract_layer_indices = {0, 2};
+    {
+        llm_graph_params params;
+        params.dflash = &dflash;
+        GGML_ASSERT(params.dflash != nullptr);
+        GGML_ASSERT(params.dflash->extract_layer_indices.size() == 2);
+        GGML_ASSERT(params.dflash->extract_layer_indices[0] == 0);
+    }
+
+    LOG_INF("test_dflash_graph_params: PASS\n");
+}
+
+//
+// Test 6: COMMON_SPECULATIVE_TYPE_DFLASH placement
+//
+static void test_dflash_speculative_type() {
+    static_assert(COMMON_SPECULATIVE_TYPE_DFLASH > COMMON_SPECULATIVE_TYPE_DRAFT_MTP,
+        "DFlash must be after DRAFT_MTP");
+    static_assert(COMMON_SPECULATIVE_TYPE_DFLASH < COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE,
+        "DFlash must be before NGRAM_SIMPLE");
+    static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 10,
+        "COUNT must be 10 with DFlash");
+    LOG_INF("test_dflash_speculative_type: PASS\n");
+}
+
+//
+// Test 7: llama_context_params target_model defaults
+//
+static void test_dflash_context_params() {
+    llama_context_params params = llama_context_default_params();
+    GGML_ASSERT(params.target_model == nullptr);
+    params.target_model = reinterpret_cast<const llama_model *>(0x1);
+    GGML_ASSERT(params.target_model != nullptr);
+    LOG_INF("test_dflash_context_params: PASS\n");
+}
+
+//
+// Test 8: DFlash API symbols resolve at link time
+//
+extern "C" {
+    LLAMA_API int32_t llama_model_dflash_block_size  (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_dflash_mask_token_id(const struct llama_model * model);
+}
+
+static void test_dflash_api_symbols() {
+    GGML_UNUSED(&llama_model_dflash_block_size);
+    GGML_UNUSED(&llama_model_dflash_mask_token_id);
+    LOG_INF("test_dflash_api_symbols: PASS\n");
+}
+
+//
+// Test 9: SWA defaults + per-layer routing (no SWA layers by default)
+//
+static void test_dflash_swa_defaults() {
+    llama_hparams hparams;
+    GGML_ASSERT(hparams.n_swa == 0);
+    GGML_ASSERT(hparams.swa_type == LLAMA_SWA_TYPE_NONE);
+    GGML_ASSERT(!hparams.is_swa_any());
+
+    // Even with SWA layers marked, is_swa_any returns true only when at least one is set
+    hparams.n_layer = 5;
+    for (uint32_t il = 0; il < 5; ++il) {
+        GGML_ASSERT(hparams.is_swa_impl[il] == 0);
+    }
+    LOG_INF("test_dflash_swa_defaults: PASS\n");
+}
+
+//
+// Test 10: SWA per-layer pattern matching Anbeeld drafter [T,T,T,T,F]
+//
+static void test_dflash_swa_anbeeld_pattern() {
+    llama_hparams hparams;
+    hparams.n_layer = 5;
+    hparams.n_swa = 2048;
+    hparams.swa_type = LLAMA_SWA_TYPE_STANDARD;
+    hparams.is_swa_impl[0] = 1;
+    hparams.is_swa_impl[1] = 1;
+    hparams.is_swa_impl[2] = 1;
+    hparams.is_swa_impl[3] = 1;
+    hparams.is_swa_impl[4] = 0;
+
+    GGML_ASSERT(hparams.is_swa_any());
+    GGML_ASSERT(hparams.is_swa(0));
+    GGML_ASSERT(hparams.is_swa(1));
+    GGML_ASSERT(hparams.is_swa(2));
+    GGML_ASSERT(hparams.is_swa(3));
+    GGML_ASSERT(!hparams.is_swa(4));
+    LOG_INF("test_dflash_swa_anbeeld_pattern: PASS\n");
+}
+
+//
+// Test 11: llm_graph_input_dflash carries n_swa through constructor
+//
+static void test_dflash_input_swa_ctor() {
+    // No SWA: n_swa defaults to 0
+    {
+        llm_graph_input_dflash input(nullptr, /*ctx_len=*/64, /*n_block=*/16);
+        GGML_ASSERT(input.n_swa == 0);
+        GGML_ASSERT(input.kq_mask_swa == nullptr);
+    }
+    // With SWA: explicit window plumbed
+    {
+        llm_graph_input_dflash input(nullptr, /*ctx_len=*/64, /*n_block=*/16, /*n_swa=*/2048);
+        GGML_ASSERT(input.n_swa == 2048);
+        // kq_mask_swa is set by build_arch_graph, not constructor — null here is correct
+        GGML_ASSERT(input.kq_mask_swa == nullptr);
+    }
+    LOG_INF("test_dflash_input_swa_ctor: PASS\n");
+}
+
+int main(void) {
+    ggml_time_init();
+
+    test_dflash_arch_registered();
+    test_dflash_tensor_infos();
+    test_dflash_hparams_defaults();
+    test_dflash_struct();
+    test_dflash_graph_params();
+    test_dflash_speculative_type();
+    test_dflash_context_params();
+    test_dflash_api_symbols();
+    test_dflash_swa_defaults();
+    test_dflash_swa_anbeeld_pattern();
+    test_dflash_input_swa_ctor();
+
+    LOG_INF("All DFlash unit tests passed.\n");
+    return 0;
+}

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -411,6 +411,9 @@ static bool arch_supported(const llm_arch arch) {
     if (arch == LLM_ARCH_DEEPSEEK2OCR) {
         return false;
     }
+    if (arch == LLM_ARCH_DFLASH) {
+        return false; // ht-only: speculative drafter — needs target_layer_ids array, synth test doesn't set it.
+    }
 
     // FIXME some models are segfaulting with WebGPU:
 #ifdef GGML_USE_WEBGPU

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -288,6 +288,7 @@ std::vector<server_tokens> tokenize_input_prompts(
 // global server parameters for chat formatting / parsing
 struct server_chat_params {
     bool use_jinja;
+    bool remap_developer_role = false; // see common_params::remap_developer_role
     bool prefill_assistant;
     common_reasoning_format reasoning_format;
     std::map<std::string, std::string> chat_template_kwargs; // mapping key --> json value
@@ -295,7 +296,6 @@ struct server_chat_params {
     bool allow_image;
     bool allow_audio;
     bool enable_thinking = true;
-    bool remap_developer_role = false;
     int  reasoning_budget = -1;
     std::string reasoning_budget_message;
     std::string media_path;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -910,6 +910,18 @@ private:
             // TODO speculative: move to common/speculative.cpp?
             const auto & params_spec = params_base.speculative.draft;
 
+            // DFlash extracts target hidden states into a single ctx_tgt-scoped buffer
+            // (dflash.target_features). Under continuous batching with n_parallel > 1,
+            // multiple slots co-decode in one batched llama_decode() call and their
+            // features interleave in that buffer, so per-slot draft() reads garbage.
+            // Until target_features is keyed per seq_id, refuse to start.
+            if (params_base.speculative.dflash && params_base.n_parallel > 1) {
+                SRV_ERR("DFlash speculative decoding requires --parallel 1 (got --parallel %d); "
+                        "multi-slot continuous batching is not yet supported by the dflash feature buffer\n",
+                        params_base.n_parallel);
+                return false;
+            }
+
             SRV_INF("loading draft model '%s'\n", params_spec.mparams.path.c_str());
 
             auto params_dft = params_base;
@@ -944,10 +956,18 @@ private:
                 cparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
             }
 
+            if (params_base.speculative.dflash) {
+                cparams.target_model = model_tgt;
+            }
+
             // note: for small models maybe we can set this to the maximum possible draft from all speculative types
             //       the extra memory for small models is likely negligible?
             cparams.n_rs_seq = 0;
             ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams));
+
+            if (params_base.speculative.dflash) {
+                llama_set_dflash(ctx_tgt, model_dft.get());
+            }
 
             ctx_dft_seq_rm_type = common_context_can_seq_rm(ctx_dft.get());
 
@@ -1233,6 +1253,7 @@ private:
 
             chat_params = {
                 /* use_jinja             */ params_base.use_jinja,
+                /* remap_developer_role  */ params_base.remap_developer_role,
                 /* prefill_assistant     */ params_base.prefill_assistant,
                 /* reasoning_format      */ params_base.reasoning_format,
                 /* chat_template_kwargs  */ params_base.default_template_kwargs,
@@ -1240,7 +1261,6 @@ private:
                 /* allow_image           */ mctx ? mtmd_support_vision(mctx) : false,
                 /* allow_audio           */ mctx ? mtmd_support_audio (mctx) : false,
                 /* enable_thinking       */ enable_thinking,
-                /* remap_developer_role  */ params_base.remap_developer_role,
                 /* reasoning_budget      */ params_base.sampling.reasoning_budget_tokens,
                 /* reasoning_budget_msg  */ params_base.sampling.reasoning_budget_message,
                 /* media_path            */ params_base.media_path,
@@ -1355,6 +1375,30 @@ private:
 
             // cache prompts only for completion tasks
             update_cache = update_cache && task.type == SERVER_TASK_TYPE_COMPLETION;
+
+            // DFlash + prompt cache reuse causes drafter NaN logits.
+            //
+            // Background: prompt cache restores the target's KV state for cached prefix tokens
+            // via llama_state_seq_set_data_ext, but DOES NOT re-extract dflash target features
+            // for those positions. After restore, only NEW tokens get decoded → only NEW token
+            // features end up in ctx_tgt's dflash.target_features buffer.
+            //
+            // Then dflash impl's draft() reads `n_new = n - dflash_n_past` features from that
+            // buffer, where `n_new` counts ALL prompt tokens (cached + new). The read overflows
+            // the buffer past its actual size (just the NEW token count) → out-of-bounds read
+            // → garbage features fed to drafter → NaN logits → 0% accept rate.
+            //
+            // Until the dflash impl learns to skip cached positions (or the cache restore path
+            // re-extracts features for them), the safest fix is to disable prompt cache reuse
+            // when this slot's task is configured for DFlash speculation. Performance impact:
+            // first request pays full prompt-eval cost; subsequent dflash requests already
+            // benefit from spec acceptance and don't strictly need prefix caching.
+            //
+            // Mission m-20260527-103737. Confirmed via cache_prompt=false workaround → 6.74%
+            // accept on the same request that hits 0% NaN with default cache_prompt=true.
+            if (params_base.speculative.dflash) {
+                update_cache = false;
+            }
 
             if (update_cache) {
                 SRV_INF("%s", "updating prompt cache\n");
@@ -2702,7 +2746,17 @@ private:
                                 continue;
                             }
 
-                            if (slot.task->params.cache_prompt) {
+                            // DFlash + per-slot prompt reuse causes drafter NaN logits. Same
+                            // bug class as the prompt_cache gate above: any path that lets the
+                            // target skip decoding cached prefix tokens means the dflash feature
+                            // buffer only has features for the NEW tokens, but the drafter still
+                            // reads n_new = n_total - dflash_n_past entries -> OOB read -> NaN.
+                            // The auto-gate at the prompt_cache load site only covers one of two
+                            // cache mechanisms. This per-slot prompt-token-reuse path (different
+                            // from the global server_prompt_cache) also has to be force-disabled
+                            // when DFlash is on. Mission m-20260527-103737.
+                            const bool dflash_active = params_base.speculative.dflash;
+                            if (slot.task->params.cache_prompt && !dflash_active) {
                                 // reuse any previously computed tokens that are common with the new prompt
                                 n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
 
@@ -2850,6 +2904,25 @@ private:
                                     );
 
                                     bool do_reset = it == slot.prompt.checkpoints.rend();
+
+                                    // DFlash + checkpoint restore is the third cache mechanism in the
+                                    // same bug class as the prompt_cache + per-slot reuse gates above.
+                                    // load_tgt restores the target's KV state for cached positions,
+                                    // but does NOT re-extract dflash target features for them. The
+                                    // subsequent decode only fills features for [n_past..n_total),
+                                    // while the drafter reads n_new = n_total - dflash_n_past entries
+                                    // (with dflash_n_past=0 right after common_speculative_begin) →
+                                    // OOB read past end of buffer → NaN logits → 0% accept.
+                                    //
+                                    // Rarely reachable with --parallel >= 4 (requests spread across
+                                    // slots, fewer checkpoints per slot), but trivially fires under
+                                    // --parallel 1 + repeated-prompt traffic. Force a full re-prefill
+                                    // when dflash is active. Mission m-20260527-103737, verified on
+                                    // titan with default cache_prompt:true going from 0/873 -> 96/1179
+                                    // (8.14%) accept on the chat-completions smoke after this gate.
+                                    if (params_base.speculative.dflash) {
+                                        do_reset = true;
+                                    }
 
                                     if (!do_reset) {
                                         // restore the context checkpoint

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -607,6 +607,30 @@ bool server_models::has_model(const std::string & name) {
     return false;
 }
 
+std::string server_models::pick_any_resident() {
+    std::lock_guard<std::mutex> lk(mutex);
+    const std::string * best_loaded   = nullptr;
+    const std::string * best_sleeping = nullptr;
+    int64_t best_loaded_used   = -1;
+    int64_t best_sleeping_used = -1;
+    for (const auto & [name, inst] : mapping) {
+        if (inst.meta.status == SERVER_MODEL_STATUS_LOADED) {
+            if (inst.meta.last_used >= best_loaded_used) {
+                best_loaded_used = inst.meta.last_used;
+                best_loaded      = &name;
+            }
+        } else if (inst.meta.status == SERVER_MODEL_STATUS_SLEEPING) {
+            if (inst.meta.last_used >= best_sleeping_used) {
+                best_sleeping_used = inst.meta.last_used;
+                best_sleeping      = &name;
+            }
+        }
+    }
+    if (best_loaded)   return *best_loaded;
+    if (best_sleeping) return *best_sleeping;
+    return {};
+}
+
 std::optional<server_model_meta> server_models::get_meta(const std::string & name) {
     std::lock_guard<std::mutex> lk(mutex);
     auto it = mapping.find(name);
@@ -1242,6 +1266,15 @@ static bool router_validate_model(std::string & name, server_models & models, bo
         res_err(res, format_error_response("model name is missing from the request", ERROR_TYPE_INVALID_REQUEST));
         return false;
     }
+    if (name == "any") {
+        // route to whichever model is currently resident in VRAM/RAM
+        std::string picked = models.pick_any_resident();
+        if (picked.empty()) {
+            res_err(res, format_error_response("no model is currently resident in memory", ERROR_TYPE_INVALID_REQUEST));
+            return false;
+        }
+        name = picked;
+    }
     auto meta = models.get_meta(name);
     if (!meta.has_value()) {
         res_err(res, format_error_response(string_format("model '%s' not found", name.c_str()), ERROR_TYPE_INVALID_REQUEST));
@@ -1416,6 +1449,9 @@ void server_models_routes::init_routes() {
                 {"status",        status},
                 {"architecture",  architecture},
                 {"need_download", meta.need_download},
+                // last-used wall-clock (epoch ms via ggml_time_ms). 0 means never used since router started.
+                // Lets clients sort by MRU when picking among resident models (e.g. heierchat's pickLoadedModel).
+                {"last_used_ms",  meta.last_used},
                 // TODO: add other fields, may require reading GGUF metadata
             };
 

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -156,6 +156,11 @@ public:
     // return discovered LoRA adapters from models directory
     std::vector<common_lora_adapter_info> get_discovered_adapters();
 
+    // resolve the "any" sentinel: pick a model that is currently resident in memory.
+    // prefers LOADED over SLEEPING, and within each tier picks the most-recently-used.
+    // returns the canonical model name, or empty string if nothing is resident.
+    std::string pick_any_resident();
+
     // load and unload model instances
     // these functions are thread-safe
     void load(const std::string & name);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -327,6 +327,20 @@ int llama_server(int argc, char ** argv) {
     sigint_action.sa_flags = 0;
     sigaction(SIGINT, &sigint_action, NULL);
     sigaction(SIGTERM, &sigint_action, NULL);
+
+    // Ignore SIGPIPE so broken-pipe writes (e.g. client disconnecting mid-stream
+    // during a chat completion) surface as EPIPE returns instead of silently
+    // killing the process. cpp-httplib calls send() with flags=0 (no MSG_NOSIGNAL),
+    // so without this any streaming client cancel during a long-running response
+    // can drop the whole llama-server child. Observed mission m-20260527-103737
+    // on titan dflash preset: 449 MiB checkpoints in flight, client cancel,
+    // child died silently — no segfault, no log line — leaving the router with
+    // a zombie/defunct backend port. SIG_IGN is the standard network-server fix.
+    struct sigaction sigpipe_action;
+    sigpipe_action.sa_handler = SIG_IGN;
+    sigemptyset(&sigpipe_action.sa_mask);
+    sigpipe_action.sa_flags = 0;
+    sigaction(SIGPIPE, &sigpipe_action, NULL);
 #elif defined (_WIN32)
     auto console_ctrl_handler = +[](DWORD ctrl_type) -> BOOL {
         return (ctrl_type == CTRL_C_EVENT) ? (signal_handler(SIGINT), true) : false;


### PR DESCRIPTION
## Summary

Replaces #53. The previous \`feat/dflash-integration\` branch (155 commits across 11 Round-N iterations) is collapsed into a single feature commit and rebased onto the post-rewrite \`ht\` (commit 5b83d6987, which sits on top of upstream master 006640408 with the per-arch class hierarchy now baseline).

## What landed

One commit, **35 files changed, +2819/-27**.

| Surface | Notes |
|---|---|
| \`src/models/dflash.cpp\` (new, 301 LOC) | \`llama_model_dflash\` — block-diffusion drafter, per-arch class |
| \`src/llama-arch.{cpp,h}\`, \`src/llama-model{.cpp,.h,-loader.cpp}\` | LLM_ARCH_DFLASH registered + tensor-load hooks + std::array<int,5> instantiation for noise schedule |
| \`src/llama-graph.{cpp,h}\` | \`llm_graph_input_dflash\` ubatch wiring, SWA-aware kq mask |
| \`src/llama-cparams.h\`, \`src/llama-hparams.h\`, \`src/llama-context.h\`, \`src/llama.cpp\` | cparams flag + ctx wiring + dispatch entry |
| \`src/models/{gemma4,llama,models}.{cpp,h}\` | per-arch hooks so existing targets cooperate with the drafter |
| \`common/speculative.{cpp,h}\` | \`COMMON_SPECULATIVE_TYPE_DFLASH\`; \`has_draft_simple\` auto-enable is now dflash/eagle3/mtp-aware |
| \`tools/server\` | router integration: \`last_used_ms\`, pick_any_resident's dflash flag, server-task/queue/server.cpp glue. \`--parallel 1\` gate kept per current Round-11 status (#107 tracks the per-seq_id path-B unblock for parallel >1) |
| \`tests/test-dflash.cpp\` + \`scripts/*\` + \`HANDOFF.md\` | Smoke harness, bench, weight-compare, Round-11 handoff |

## Conflict resolutions vs the previous attempt

- \`swa_layers\` → \`is_swa_impl\` rename (upstream restructured \`llama_hparams\`).
- Single \`remap_developer_role\` in \`server_chat_params\` (both branches independently added it).
- AGENTS.md kept the downstream-focused resource list and the AI-maintainer-tier note; dropped the upstream anti-AI policy block (doesn't apply to this fork).
- print_mask is now templated upstream; kept the templated signature and dropped dflash's pre-template duplicate.

## Verified

- ✅ \`cmake -B build -DGGML_CPU=ON -DLLAMA_BUILD_APP=ON\` configures clean.
- ✅ \`cmake --build build --target llama-server\` builds end-to-end (100%).
- ✅ One harmless \`-Wswitch\` warning for \`COMMON_SPECULATIVE_TYPE_DFLASH\` in an unrelated switch — pre-existing on the dflash branch.

## Follow-ups

- **CUDA build verification** — this PR was CPU-only verified.
- **Round-11 lifecycle bug** (Task #107): per-seq_id \`target_features\` for \`--parallel\` > 1 still open.
- **Splitting into ~5 logical commits** (Task #108) — held; this is single-commit-squash for now to keep the rebase tractable. Can split later if Markus prefers a 5-commit narrative.