### PR TITLE
fix(server): portable exit-code on subprocess-alive=false path (windows build break)

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -920,7 +920,15 @@ void server_models::load(const std::string & name) {
                 // but that cleanup can stall on log_thread.join() if the stdout pipe isn't
                 // EOFing (e.g. another process inherited the write end). Setting status here
                 // breaks the "500 forever" loop even when the management thread is stuck.
-                this->update_status(name, SERVER_MODEL_STATUS_UNLOADED, child_proc->return_status);
+                //
+                // subprocess_join() is the portable way to read the exit code —
+                // subprocess_s::return_status exists only on POSIX (the Windows variant uses
+                // hProcess + GetExitCodeProcess via subprocess_join). subprocess_alive()
+                // already reaped the zombie on POSIX, so subprocess_join() returns
+                // immediately with the cached status.
+                int child_exit = 0;
+                subprocess_join(child_proc.get(), &child_exit);
+                this->update_status(name, SERVER_MODEL_STATUS_UNLOADED, child_exit);
                 // Force the stdout pipe read end closed so log_thread's fgets() returns and
                 // the outer thread can proceed past log_thread.join().
                 if (child_proc->stdout_file) {


### PR DESCRIPTION
## Why

Every Windows build job on PRs #62 and #63 is failing with:

```
tools/server/server-models.cpp:923:85: error: no member named 'return_status' in 'subprocess_s'
```

`subprocess_s::return_status` is defined only in the POSIX branch of vendor/sheredom/subprocess.h:402-418. The Windows variant uses `hProcess` instead, so the direct field access doesn't compile.

## Fix

Replace the direct field access with `subprocess_join(child_proc.get(), &child_exit)` — same pattern already used at line 908 of the same file. `subprocess_alive()` has already reaped the zombie on POSIX, so `subprocess_join()` returns immediately with the cached status (no risk of re-blocking on a stuck child).

```diff
- this->update_status(name, SERVER_MODEL_STATUS_UNLOADED, child_proc->return_status);
+ int child_exit = 0;
+ subprocess_join(child_proc.get(), &child_exit);
+ this->update_status(name, SERVER_MODEL_STATUS_UNLOADED, child_exit);
```

## Impact

- Unblocks Windows builds on PR #62 (DFlash rebase) and PR #63 (TBQ test fix).
- No behavior change on POSIX — `subprocess_join` just returns `process->return_status`.
- Local CPU build passes.

## Verified

- ✅ `cmake -B build -DGGML_CPU=ON -DLLAMA_BUILD_APP=ON && cmake --build build --target llama-server` succeeds locally.
- ✅ Only one file touched, 1 LOC of real change.