### PR TITLE
feat(fit): expose per-device byte plan from common_fit_params (#66 step 1)

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -153,7 +153,8 @@ std::vector<llama_device_memory_data> common_get_device_memory_data(
 static void common_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level) {
+        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level,
+        std::vector<int64_t> * out_bytes_per_device) {
     if (mparams->split_mode == LLAMA_SPLIT_MODE_TENSOR) {
         throw common_params_fit_exception("llama_params_fit is not implemented for SPLIT_MODE_TENSOR, abort");
     }
@@ -616,6 +617,9 @@ static void common_params_fit_impl(
     }
     if (hp_nex == 0 || global_surplus_cpu_moe <= 0) {
         set_ngl_tensor_split_tbo(ngl_per_device, overflow_bufts, *mparams);
+        if (out_bytes_per_device) {
+            *out_bytes_per_device = mem;
+        }
         return;
     }
 
@@ -761,6 +765,9 @@ static void common_params_fit_impl(
     }
 
     set_ngl_tensor_split_tbo(ngl_per_device, overflow_bufts, *mparams);
+    if (out_bytes_per_device) {
+        *out_bytes_per_device = mem;
+    }
 }
 
 enum common_params_fit_status common_fit_params(
@@ -771,11 +778,12 @@ enum common_params_fit_status common_fit_params(
         llama_model_tensor_buft_override * tensor_buft_overrides,
         size_t * margins,
         uint32_t n_ctx_min,
-        ggml_log_level log_level) {
+        ggml_log_level log_level,
+        std::vector<int64_t> * out_bytes_per_device) {
     const int64_t t0_us = llama_time_us();
     common_params_fit_status status = COMMON_PARAMS_FIT_STATUS_SUCCESS;
     try {
-        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level);
+        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level, out_bytes_per_device);
         LOG_TRC("%s: successfully fit params to free device memory\n", __func__);
     } catch (const common_params_fit_exception & e) {
         LOG_WRN("%s: failed to fit params to free device memory: %s\n", __func__, e.what());

--- a/common/fit.h
+++ b/common/fit.h
@@ -18,6 +18,11 @@ enum common_params_fit_status {
 //   - this function is NOT thread safe because it modifies the global llama logger state
 //   - only parameters that have the same value as in llama_default_model_params are modified
 //     with the exception of the context size which is modified if and only if equal to 0
+//   - if `out_bytes_per_device` is non-null, it is resized to the device-count and populated
+//     with the projected per-device byte demand for the resolved plan. Index 0 is the CPU
+//     device, indices 1..N are GPU/accel devices in the same order as `tensor_split`. The
+//     router uses this to admit candidates against per-device free-after-reserved memory
+//     instead of total-pool memory (see ht-llama.cpp issue #66). Populated on SUCCESS only.
 enum common_params_fit_status common_fit_params(
                                const char   * path_model,
                 struct llama_model_params   * mparams,
@@ -26,7 +31,8 @@ enum common_params_fit_status common_fit_params(
     struct llama_model_tensor_buft_override * tensor_buft_overrides, // writable buffer for overrides, needs at least llama_max_tensor_buft_overrides elements
                                      size_t * margins,               // margins of memory to leave per device in bytes
                                    uint32_t   n_ctx_min,             // minimum context size to set when trying to reduce memory use
-                        enum ggml_log_level   log_level);            // minimum log level to print during fitting, lower levels go to debug log
+                        enum ggml_log_level   log_level,             // minimum log level to print during fitting, lower levels go to debug log
+                   std::vector<int64_t>     * out_bytes_per_device = nullptr); // per-device projected byte demand (ht; see #66)
 
 // print estimated memory to stdout
 void common_fit_print(


### PR DESCRIPTION
Issue #66 step 1 — foundation for per-GPU-aware router fit.

## What

Adds an optional `out_bytes_per_device` output parameter to `common_fit_params` (defaults to `nullptr` so existing callers are unaffected). On SUCCESS, populates with the projected per-device byte demand for the resolved plan.

```cpp
std::vector<int64_t> plan;
common_fit_params(path, &mparams, &cparams, ts, tbo, margins, n_ctx_min,
                  GGML_LOG_LEVEL_INFO, &plan);
// plan[0] = CPU bytes, plan[1..N] = GPU/accel bytes
```

## Why

The router currently admits candidates against TOTAL VRAM via `common_fit_params` + `--models-max`. Two models pinned to CUDA0 (`tensor-split=100,0`) collide on GPU0's 24 GiB even though the 48 GiB pool says they fit — see issue #66 for the exact prod signature and snoop-kube's deterministic repro.

## How

Both `common_params_fit_impl` exit paths (the early MoE-trivial path at the previous line 619, and the full-search path at line 763) populate the output from the `mem` vector that fit_impl already computes. No behavior change for `nullptr` callers.

```diff
 static void common_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level) {
+        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level,
+        std::vector<int64_t> * out_bytes_per_device) {
```

## What this is NOT

This PR doesn't wire the output anywhere — it's the foundation. Subsequent PRs (each separate, each independently shippable):

- **Step 2**: track `reserved_per_device[]` in `server_models`, updated on load (+) and unload (-).
- **Step 3**: replace count-only `unload_lru()` with `unload_lru_for_devices(targeted, candidate_per_device)`.
- **Step 4**: wire admit decision against `free_device[d] - reserved[d]` per targeted device.

## Verified

- ✅ `cmake -B build -DGGML_CPU=ON -DLLAMA_BUILD_APP=ON && cmake --build build --target llama-server` succeeds.
- ✅ No call sites needed updates (default-nullptr parameter).
- ✅ Master sync friction: one new parameter, default nullptr — trivial to resolve if upstream changes the signature.

## Test plan after merge

Snoop-kube has a deterministic repro: load devstral-24b (CUDA0), then request gemma-4-31b-iq4 (also CUDA0). Today this OOMs at the second admit. After step 2-4 land + a canary roll, the same sequence should: (a) succeed if there's room after evictions, or (b) cleanly 503 with `model_unavailable_error` if not — never OOM.