### PR TITLE
ci(sycl): drop auto-triggers (workflow has zero jobs upstream)

### DIFF
--- a/.github/workflows/build-sycl.yml
+++ b/.github/workflows/build-sycl.yml
@@ -1,26 +1,15 @@
 name: CI (sycl)
 
+# Note: the SYCL jobs in this file are disabled upstream (see PR
+# ggml-org/llama.cpp#23705) — all matrix entries below are commented out to save
+# Actions resources. With the upstream auto-triggers, every push to master (e.g.
+# our fork-sync) creates a zero-job "failure" run, polluting the Actions
+# dashboard. Auto-triggers stripped on ht; `workflow_dispatch` remains so the
+# job can be invoked manually if/when upstream re-enables SYCL CI. Re-add the
+# upstream trigger block when SYCL jobs land.
+
 on:
   workflow_dispatch: # allows manual triggering
-  push:
-    branches:
-      - master
-    paths: [
-      '.github/workflows/build-sycl.yml',
-      '**/CMakeLists.txt',
-      '**/.cmake',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp'
-    ]
-
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-sycl.yml',
-      'ggml/src/ggml-sycl/**'
-    ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}


### PR DESCRIPTION
Epoch #73 task 1: CI health.

## What

All SYCL jobs in `.github/workflows/build-sycl.yml` are commented out upstream ([ggml-org/llama.cpp#23705](https://github.com/ggml-org/llama.cpp/pull/23705)) to save GitHub Actions resources. With the upstream auto-triggers (push to master, pull_request matching ggml/src/ggml-sycl/**) still firing, every fork-sync that touches master creates a zero-job "failure" run and pollutes our Actions dashboard.

## Diff

Strip `push` + `pull_request` blocks from `on:`; keep `workflow_dispatch` so the job stays manually invokable.

```diff
 on:
   workflow_dispatch: # allows manual triggering
-  push:
-    branches:
-      - master
-    paths: [
-      '.github/workflows/build-sycl.yml',
-      '**/CMakeLists.txt',
-      ...
-    ]
-
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-sycl.yml',
-      'ggml/src/ggml-sycl/**'
-    ]
```

## Maintenance note

Master sync (#119 was the last one) brings in the upstream version of this file, which re-introduces the auto-triggers. The note in the file body explains what to re-apply after a sync. Filing as a recurring 'fix after master sync' item; may want a CI-side check that flags zero-job workflow runs eventually.

## Verified

- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/build-sycl.yml"))'` — YAML parses
- `workflow_dispatch:`-only workflows are valid in GitHub Actions (no `jobs:` block required when there are no auto-triggers; though we still keep the commented-out block intact for the manual dispatch path to invoke when re-enabled)