### PR TITLE
fix(server): guard two mapping[] accesses against silent default-insert

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -759,7 +759,14 @@ void server_models::unload_lru() {
         {
             std::unique_lock<std::mutex> lk(mutex);
             cv.wait(lk, [this, &lru_model_name]() {
-                return mapping[lru_model_name].meta.status == SERVER_MODEL_STATUS_UNLOADED;
+                // operator[] on std::map silently default-inserts on miss; with a
+                // default-init server_model_meta (status = UNLOADED) the predicate
+                // would spuriously return true AND pollute mapping. Use find().
+                // Missing model → treat as done (was unloaded by another thread or
+                // removed by a concurrent reload).
+                auto it = mapping.find(lru_model_name);
+                if (it == mapping.end()) return true;
+                return it->second.meta.status == SERVER_MODEL_STATUS_UNLOADED;
             });
         }
     }
@@ -776,7 +783,16 @@ void server_models::load(const std::string & name) {
     // against the freshest preset and a consistent mapping state
     cv.wait(lk, [this]() { return !is_reloading; });
 
-    auto meta = mapping[name].meta;
+    // Use find() instead of operator[]: a concurrent reload between has_model()
+    // (above, lock-released) and this point can erase the entry. operator[]
+    // would silently default-insert (status = UNLOADED) and we'd spawn a child
+    // with empty preset args. Treat missing as "model was removed", bail out.
+    auto map_it = mapping.find(name);
+    if (map_it == mapping.end()) {
+        SRV_INF("model %s was removed by a concurrent reload, aborting load\n", name.c_str());
+        return;
+    }
+    auto meta = map_it->second.meta;
     if (meta.status != SERVER_MODEL_STATUS_UNLOADED) {
         SRV_INF("model %s is not ready\n", name.c_str());
         return;


### PR DESCRIPTION
Epoch #73 task 4. Bug-hunt sweep on tools/server/server-models.cpp found two race-condition latent bugs in the router state machine. Both used `std::map::operator[]` where `find()` was needed.

## Bug 1: unload_lru() cv.wait predicate (line 762)

```cpp
cv.wait(lk, [&]() {
    return mapping[lru_model_name].meta.status == SERVER_MODEL_STATUS_UNLOADED;
});
```

Default-init `server_model_meta::status` = `SERVER_MODEL_STATUS_UNLOADED`. If `lru_model_name` is missing (concurrent reload erased it, or another thread already unloaded + removed), `operator[]` silently inserts a default — predicate is spuriously true AND mapping is polluted with a phantom entry.

**Fix:** `find()`; missing → treat as done (no entry to wait for).

## Bug 2: load() after cv.wait(!is_reloading) (line 779)

```cpp
cv.wait(lk, [this]() { return !is_reloading; });
auto meta = mapping[name].meta;
```

`has_model(name)` was checked at line 770 under its own lock-cycle, then `unload_lru()` cycled the lock, then we re-acquire here. A reload in that window could erase `name` from mapping; `mapping[name]` then silently default-inserts. The early-return check (status != UNLOADED) is bypassed (default = UNLOADED) and we proceed to spawn a child with empty preset args.

**Fix:** `find()`; missing → log + bail.

## Out of scope

Other `mapping[]` sites in load() (lines 1020, 1031) are reachable only while the lock is held continuously from the now-guarded read at 779, so no race exists. `mapping[name]` at line 1186 (`proxy_request`) also reads under-lock after `get_meta()` confirmed presence.

## Verified

- ✅ `cmake -B build -DGGML_CPU=ON -DLLAMA_BUILD_APP=ON && cmake --build build --target llama-server` succeeds
- ✅ No behavior change on the non-racy path: `find()` + early-return on miss is operationally equivalent to `operator[]` + early-return on default-UNLOADED, minus the silent insertion