### PR TITLE
perf(dflash): gate top-5 logits diagnostic behind LLAMA_DFLASH_DEBUG

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -932,7 +932,13 @@ struct common_speculative_impl_dflash : public common_speculative_impl {
 
                 const llama_token id = (llama_token)(std::max_element(logits, logits + n_vocab) - logits);
 
-                if (i == 1) {
+                // Top-5 logits diagnostic — gated behind LLAMA_DFLASH_DEBUG (cached
+                // at line 883). The selection loop is O(n_vocab * log 5) per draft
+                // call; one call per generated-token-attempt and several per output
+                // token at typical accept rates. On gemma-class vocabs (~256k) it
+                // would burn ~1ms per draft on production where the LOG_INF would
+                // be suppressed by verbosity anyway.
+                if (i == 1 && dflash_debug) {
                     std::vector<int> top;
                     top.reserve(5);
                     for (int j = 0; j < n_vocab; ++j) {


### PR DESCRIPTION
Epoch #73 task 5 (DFlash perf scout, in lieu of titan-gated bench).

## Finding

`common/speculative.cpp:935` has an unconditional top-5 logits selection inside the DFlash drafter's hot path:

```cpp
if (i == 1) {
    std::vector<int> top;
    top.reserve(5);
    for (int j = 0; j < n_vocab; ++j) {
        if ((int) top.size() < 5) {
            top.push_back(j);
            std::sort(top.begin(), top.end(), [&](int a, int b) { return logits[a] > logits[b]; });
        } else if (logits[j] > logits[top.back()]) {
            top.back() = j;
            std::sort(top.begin(), top.end(), [&](int a, int b) { return logits[a] > logits[b]; });
        }
    }
    // build top_dbg string and LOG_INF
}
```

The `if (i == 1)` gates *when* (once per draft call) but not *whether*. The `LOG_INF` below is verbosity-gated, so on production the log is suppressed — but the O(n_vocab × log 5) selection still runs.

On gemma-class vocabs (~256k tokens), that's ~1ms per draft call. At Round-10's measured ~8% accept rate, every output token costs several draft calls — so this debug computation is in the steady-state hot path.

## Fix

Extend the gate to `if (i == 1 && dflash_debug)`. `dflash_debug` is the cached env-var probe already declared at line 883 (used by the features-debug block immediately above).

## Verified

- ✅ `cmake --build build --target llama-server` succeeds
- ✅ Behavior change: only when `LLAMA_DFLASH_DEBUG` is set (was unconditional → now gated; identical code runs when enabled)

## Out of scope

Other DFlash hot-path observations from the scout that did NOT make this PR (no clear-win fix):
- `accumulated_ctx` grows unboundedly across draft calls. With default `LLAMA_DFLASH_CTX_WINDOW=512` only the tail is used, but the buffer keeps growing. Memory leak shape, not perf. Worth a follow-up trim.
- `std::sort` inside the j-loop is asymptotically fine but has a 5-element sort per insertion. Could be replaced by a hand-rolled 5-slot insertion-sort (O(5) vs O(5 log 5 × n_vocab) constant factor). Speed-up is small and only matters when DFLASH_DEBUG=1.