### PR TITLE
ci(cann): drop auto-triggers (workflow has zero jobs upstream)

### DIFF
--- a/.github/workflows/build-cann.yml
+++ b/.github/workflows/build-cann.yml
@@ -2,25 +2,11 @@ name: CI (cann)
 
 on:
   workflow_dispatch: # allows manual triggering
-  push:
-    branches:
-      - master
-    paths: [
-      '.github/workflows/build-cann.yml',
-      '**/CMakeLists.txt',
-      '**/.cmake',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp'
-    ]
-
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-cann.yml',
-      'ggml/src/ggml-cann/**'
-    ]
+  # Auto-triggers disabled: every job in this workflow was commented out
+  # by upstream PR #23705 to save Github Actions resources. Leaving the
+  # auto-triggers active creates zero-job "failure" runs on PRs that
+  # touch ggml/src/ggml-cann/**. See PR #74 for the same fix on
+  # build-sycl.yml. Re-enable in lockstep with the upstream re-enable.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}


### PR DESCRIPTION
## Summary

Same pattern as PR #74 — `build-cann.yml` has had every job commented out since upstream PR #23705, but kept its `push:master` + `pull_request` auto-triggers. Any PR touching `ggml/src/ggml-cann/**` would produce a zero-job "failure" run on this workflow.

This PR strips those auto-triggers and keeps only `workflow_dispatch`, so the workflow can still be invoked manually if/when jobs are re-enabled.

## Why this hasn't fired yet on ht
Unlike `build-sycl.yml` (which has a path filter that matches almost any C/C++ change), the CANN pull_request path filter is narrow: `ggml/src/ggml-cann/**`. No recent PR has touched those files, so the zero-job failure runs haven't materialized. They will the next time a contributor touches CANN code.

## Test plan
- [x] yaml validates
- [ ] (post-merge) confirm no new build-cann runs fire on regular PRs

## Related
- PR #74 — same fix on build-sycl.yml
- Upstream PR #23705 — the disable

🤖 Generated with [Claude Code](https://claude.com/claude-code)