### PR TITLE
fix(server): Responses API emits incomplete status on truncation (#19)

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1003,6 +1003,15 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
         msg.content = content;
     }
 
+    // Propagate truncation to the OAI Responses status (issue #19): when the
+    // generation hit max_output_tokens / ctx limit, mark output items and the
+    // top-level response as "incomplete" with the reason. Otherwise agentic
+    // clients can't distinguish a finished response from a truncated one and
+    // end up retrying with the malformed/partial output in conversation
+    // history.
+    const bool is_incomplete = (stop == STOP_TYPE_LIMIT);
+    const char * item_status = is_incomplete ? "incomplete" : "completed";
+
     std::vector<json> output;
 
     if (msg.reasoning_content != "") {
@@ -1015,7 +1024,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
                 {"type", "reasoning_text"},
             }})},
             {"encrypted_content", ""},
-            {"status",            "completed"},
+            {"status",            item_status},
         });
     }
 
@@ -1029,7 +1038,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
             }})},
             {"id",     "msg_" + random_string()},
             {"role",   msg.role},
-            {"status", "completed"},
+            {"status", item_status},
             {"type",   "message"},
         });
     }
@@ -1037,7 +1046,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
     for (const common_chat_tool_call & tool_call : oaicompat_msg.tool_calls) {
         output.push_back(json {
             {"type",      "function_call"},
-            {"status",    "completed"},
+            {"status",    item_status},
             {"arguments", tool_call.arguments},
             {"call_id",   "fc_" + tool_call.id},
             {"name",      tool_call.name},
@@ -1052,7 +1061,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
         {"model",        oaicompat_model},
         {"object",       "response"},
         {"output",       output},
-        {"status",       "completed"},
+        {"status",       is_incomplete ? "incomplete" : "completed"},
         {"usage",        json {
             {"input_tokens",  n_prompt_tokens},
             {"output_tokens", n_decoded},
@@ -1061,12 +1070,22 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
         }},
     };
 
+    if (is_incomplete) {
+        res["incomplete_details"] = json {{"reason", "max_output_tokens"}};
+    }
+
     return res;
 }
 
 json server_task_result_cmpl_final::to_json_oaicompat_resp_stream() {
     std::vector<json> server_sent_events;
     std::vector<json> output;
+
+    // See to_json_oaicompat_resp() for the issue-#19 background. Same mapping
+    // here so streaming clients see the truncation in the final
+    // response.completed event payload and on the per-item statuses.
+    const bool is_incomplete = (stop == STOP_TYPE_LIMIT);
+    const char * item_status = is_incomplete ? "incomplete" : "completed";
 
     if (oaicompat_msg.reasoning_content != "") {
         const json output_item = json {
@@ -1117,7 +1136,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp_stream() {
         });
         const json output_item = {
             {"type",    "message"},
-            {"status",  "completed"},
+            {"status",  item_status},
             {"id",      oai_resp_message_id},
             {"content", json::array({content_part})},
             {"role",    "assistant"}
@@ -1136,7 +1155,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp_stream() {
     for (const common_chat_tool_call & tool_call : oaicompat_msg.tool_calls) {
         const json output_item = {
             {"type",      "function_call"},
-            {"status",    "completed"},
+            {"status",    item_status},
             {"arguments", tool_call.arguments},
             {"call_id",   "fc_" + tool_call.id},
             {"name",      tool_call.name}
@@ -1152,24 +1171,29 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp_stream() {
     }
 
     std::time_t t = std::time(0);
+    json response_payload = json {
+        {"id",         oai_resp_id},
+        {"object",     "response"},
+        {"created_at", t},
+        {"status",     is_incomplete ? "incomplete" : "completed"},
+        {"model",      oaicompat_model},
+        {"output",     output},
+        {"usage",      json {
+            {"input_tokens",  n_prompt_tokens},
+            {"output_tokens", n_decoded},
+            {"total_tokens",  n_decoded + n_prompt_tokens},
+            {"input_tokens_details", json { {"cached_tokens", n_prompt_tokens_cache} }},
+        }}
+    };
+    if (is_incomplete) {
+        response_payload["incomplete_details"] = json {{"reason", "max_output_tokens"}};
+    }
+
     server_sent_events.push_back(json {
-        {"event", "response.completed"},
+        {"event", is_incomplete ? "response.incomplete" : "response.completed"},
         {"data", json {
-            {"type", "response.completed"},
-            {"response", json {
-                {"id",         oai_resp_id},
-                {"object",     "response"},
-                {"created_at", t},
-                {"status",     "completed"},
-                {"model",      oaicompat_model},
-                {"output",     output},
-                {"usage",      json {
-                    {"input_tokens",  n_prompt_tokens},
-                    {"output_tokens", n_decoded},
-                    {"total_tokens",  n_decoded + n_prompt_tokens},
-                    {"input_tokens_details", json { {"cached_tokens", n_prompt_tokens_cache} }},
-                }}
-            }},
+            {"type",     is_incomplete ? "response.incomplete" : "response.completed"},
+            {"response", response_payload},
         }}
     });
 

--- a/tools/server/tests/unit/test_compat_oai_responses.py
+++ b/tools/server/tests/unit/test_compat_oai_responses.py
@@ -71,3 +71,63 @@ def test_responses_stream_with_openai_library():
             assert r.response.output[0].id.startswith("msg_")
             assert gathered_text == r.response.output_text
             assert match_regex("(Suddenly)+", r.response.output_text)
+
+
+# Issue #19: truncated responses must signal status=incomplete +
+# incomplete_details, otherwise agentic clients can't tell the response was
+# cut short and may try to use partial output as conversation history.
+def test_responses_truncation_emits_incomplete_status():
+    global server
+    server.start()
+    res = server.make_request("POST", "/v1/responses", data={
+        "model": "tinyllama-2",
+        "input": [
+            {"role": "system", "content": "Book"},
+            {"role": "user", "content": "What is the best book"},
+        ],
+        # tinyllama2 has no eos in this generation pattern, so a small cap
+        # reliably trips STOP_TYPE_LIMIT before any natural stop.
+        "max_output_tokens": 2,
+        "temperature": 0.8,
+    })
+    assert res.status_code == 200, res.body
+    body = res.body
+    assert body["status"] == "incomplete", body
+    assert body.get("incomplete_details", {}).get("reason") == "max_output_tokens", body
+    # downstream items inherit the same status so agent clients can detect
+    # partial tool_calls / partial messages at the per-item level
+    for item in body["output"]:
+        assert item.get("status") == "incomplete", item
+
+
+def test_responses_truncation_stream_emits_incomplete_event():
+    global server
+    server.start()
+    # use the raw POST so we get raw SSE; the openai client coerces
+    # response.incomplete into something different.
+    res = server.make_stream_request("POST", "/v1/responses", data={
+        "model": "tinyllama-2",
+        "input": [
+            {"role": "system", "content": "Book"},
+            {"role": "user", "content": "What is the best book"},
+        ],
+        "max_output_tokens": 2,
+        "temperature": 0.8,
+        "stream": True,
+    })
+    saw_incomplete = False
+    final_status = None
+    final_reason = None
+    for chunk in res:
+        if not chunk:
+            continue
+        # chunks come as parsed dicts from the helper
+        ctype = chunk.get("type")
+        if ctype == "response.incomplete":
+            saw_incomplete = True
+            r = chunk.get("response", {})
+            final_status = r.get("status")
+            final_reason = (r.get("incomplete_details") or {}).get("reason")
+    assert saw_incomplete, "no response.incomplete event in stream"
+    assert final_status == "incomplete"
+    assert final_reason == "max_output_tokens"


### PR DESCRIPTION
## Summary

Closes Phase 1 of #19: when generation hits `STOP_TYPE_LIMIT` (max_output_tokens / ctx-size cap), the OAI Responses code paths used to hardcode `"status": "completed"` on the top-level response, all output items, and the streaming `response.completed` SSE event. Agentic clients (Codex CLI, etc.) couldn't tell a finished response from a truncated one — they fed partial output back into conversation history, triggering JSON-parse-failure 500s on the next request and infinite retry loops.

Per the OAI Responses spec:
- Top-level `status` flips to `"incomplete"` on truncation.
- New top-level `incomplete_details: { reason: "max_output_tokens" }` field.
- Per-item `status` (message / reasoning / function_call) inherits the same value, so clients can detect partial tool_calls / partial messages at the per-item level.
- Streaming variant: final SSE event becomes `response.incomplete` (instead of `response.completed`), with the same payload shape.

## What this does *not* do

Phase 2 of #19 (HTTP 400 + actionable message from `func_args_not_string`) is intentionally out of scope. That requires typed-exception plumbing through `common/chat.cpp` into the server error path — a separate, bigger change. Phase 1 alone prevents the cascade in the first place: once clients see truncation **as** truncation, they don't retry with malformed history.

## Test plan
- [x] `tools/server/tests/unit/test_compat_oai_responses.py::test_responses_truncation_emits_incomplete_status` — non-streaming repro with `max_output_tokens: 2` on tinyllama2 (reliably trips STOP_TYPE_LIMIT). Asserts top-level `status=incomplete` + `incomplete_details.reason=max_output_tokens` + per-item status.
- [x] `test_responses_truncation_stream_emits_incomplete_event` — streaming repro. Verifies a `response.incomplete` event arrives with the same payload shape.
- [x] Two pre-existing `test_responses_with_openai_library` / `test_responses_stream_with_openai_library` tests still pass (no happy-path regression).
- [ ] (manual, post-merge) re-run the original Codex CLI repro from the issue to confirm the retry loop is broken.

## Files touched
- `tools/server/server-task.cpp` — both `to_json_oaicompat_resp` and `to_json_oaicompat_resp_stream`
- `tools/server/tests/unit/test_compat_oai_responses.py` — 2 new test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)