### PR TITLE
fix(server): clean up orphaned results when removing batch of task ids

### DIFF
--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -261,6 +261,21 @@ void server_response::remove_waiting_task_ids(const std::unordered_set<int> & id
         RES_DBG("remove task %d from waiting list. current waiting = %d (before remove)\n", id_task, (int) waiting_task_ids.size());
         waiting_task_ids.erase(id_task);
     }
+
+    // Symmetry with remove_waiting_task_id: also drop any pending results
+    // whose task ids are in the removed set. Without this, a reader that
+    // tears down mid-stream (HTTP client disconnect, abort) can leave
+    // orphaned partial results in queue_results — they never match any
+    // future recv() call's id_tasks set, but the predicate
+    // !queue_results.empty() in recv() is still true, so the next recv()
+    // for an unrelated id can spin-wait at 100% CPU until that task's
+    // result also arrives.
+    queue_results.erase(
+        std::remove_if(queue_results.begin(), queue_results.end(),
+            [&id_tasks](const server_task_result_ptr & res) {
+                return id_tasks.find(res->id) != id_tasks.end();
+            }),
+        queue_results.end());
 }
 
 server_task_result_ptr server_response::recv(const std::unordered_set<int> & id_tasks) {
@@ -428,6 +443,12 @@ server_response_reader::batch_response server_response_reader::wait_for_all(cons
 }
 
 void server_response_reader::stop() {
+    // remove_waiting_task_ids now also clears pending results for the same
+    // ids (see server_response::remove_waiting_task_ids), so the per-id
+    // remove_waiting_task_id calls that used to live in the cancel loop
+    // are no longer needed — they were redundant on the happy path and
+    // they were the only thing covering the orphan case before the
+    // remove_waiting_task_ids fix.
     queue_results.remove_waiting_task_ids(id_tasks);
     if (has_next() && !cancelled) {
         // if tasks is not finished yet, cancel them
@@ -438,7 +459,6 @@ void server_response_reader::stop() {
             SRV_WRN("cancel task, id_task = %d\n", id_task);
             server_task task(SERVER_TASK_TYPE_CANCEL);
             task.id_target = id_task;
-            queue_results.remove_waiting_task_id(id_task);
             cancel_tasks.push_back(std::move(task));
         }
         // push to beginning of the queue, so it has highest priority


### PR DESCRIPTION
## Summary

Bug-hunt round 3 finding (sweep on `tools/server/server-queue.cpp`). The multi-id variant `server_response::remove_waiting_task_ids` only erased entries from `waiting_task_ids` — its single-id sibling `remove_waiting_task_id` also dropped any pending entries in `queue_results` for the same id. That asymmetry leaks orphaned partials when a reader tears down mid-stream.

## Why this matters

When an HTTP client disconnects mid-stream (or any other path that triggers `~server_response_reader → stop()` while results are still in flight):

1. `stop()` calls `remove_waiting_task_ids(id_tasks)` — clears waiting set, but leaves matching partials sitting in `queue_results`.
2. Cancel branch (`has_next() && !cancelled`) may or may not run depending on state; even when it does, the per-id cleanup in the cancel loop only covers the not-yet-finished case.
3. Orphaned partials accumulate. They never match any future `recv()` call's `id_tasks`, but the cv.wait predicate `!queue_results.empty()` is satisfied, so the next `recv()` for an unrelated task spin-waits at 100% CPU until its own result arrives and the for-loop finds it.

## Fix

Make `remove_waiting_task_ids` clean up `queue_results` symmetrically with `remove_waiting_task_id`, then drop the now-redundant per-id calls from `server_response_reader::stop()`'s cancel loop. Inline comment explains the spin-wait failure mode for future readers.

## Caller audit
- `remove_waiting_task_ids` has exactly one production callsite (`server_response_reader::stop`). Limited blast radius.
- `remove_waiting_task_id` (single-id) still in use by per-task cleanup; unchanged.
- The dropped per-id calls in stop()'s cancel loop were 1 extra mutex acquire per cancelled task; removing them is a minor perf side effect.

## Test plan
- [x] Local rebuild (CPU) clean.
- [x] 45/46 server unit tests pass (the 1 failure is a network-bound model download unrelated to this change).
- [ ] No new test added: triggering this requires mid-stream client disconnect with another in-flight task — observable only via CPU usage and only racey to reproduce. Code change is small, comment is explicit, and the symmetry argument is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)