### PR TITLE
docs(server): drop phantom --talker-model + --code2wav-model rows

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -175,8 +175,6 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-np, --parallel N` | number of server slots (default: -1, -1 = auto)<br/>(env: LLAMA_ARG_N_PARALLEL) |
 | `-cb, --cont-batching, -nocb, --no-cont-batching` | whether to enable continuous batching (a.k.a dynamic batching) (default: enabled)<br/>(env: LLAMA_ARG_CONT_BATCHING) |
 | `-mm, --mmproj FILE` | path to a multimodal projector file. see tools/mtmd/README.md<br/>note: if -hf is used, this argument can be omitted<br/>(env: LLAMA_ARG_MMPROJ) |
-| `-tk, --talker-model FILE` | path to the qwen3-omni talker gguf, enables the /v1/audio/speech endpoint<br/>(env: LLAMA_ARG_TALKER_MODEL) |
-| `-c2w, --code2wav-model FILE` | path to the qwen3-omni code2wav gguf, the talker code detokenizer<br/>(env: LLAMA_ARG_CODE2WAV_MODEL) |
 | `-mmu, --mmproj-url URL` | URL to a multimodal projector file. see tools/mtmd/README.md<br/>(env: LLAMA_ARG_MMPROJ_URL) |
 | `--mmproj-auto, --no-mmproj, --no-mmproj-auto` | whether to use multimodal projector file (if available), useful when using -hf (default: enabled)<br/>(env: LLAMA_ARG_MMPROJ_AUTO) |
 | `--mmproj-offload, --no-mmproj-offload` | whether to enable GPU offloading for multimodal projector (default: enabled)<br/>(env: LLAMA_ARG_MMPROJ_OFFLOAD) |


### PR DESCRIPTION
## Summary

Epoch #81 task 5 (docs review on \`tools/server/README.md\`). The server-specific params table at lines 178-179 documented two flags that don't exist on this fork:

| Phantom flag | Help text claims | Reality |
|---|---|---|
| \`--talker-model FILE\` | "enables the /v1/audio/speech endpoint" | No \`talker\` in \`common/arg.cpp\` or any C++ source; \`/v1/audio/speech\` is not a registered route (only \`/v1/audio/transcriptions\` exists via \`routes.post_transcriptions_oai\` in \`server.cpp:198\`) |
| \`--code2wav-model FILE\` | "qwen3-omni code2wav gguf" | No \`code2wav\` in arg.cpp or C++ source; only appears in \`conversion/qwen3.py\` as a tensor-name prefix in the GGUF converter, which is unrelated to runtime flags |

The webui *does* reference \`/v1/audio/speech\` — but only in its TTS *client* code (calling out to an external OpenAI-compatible TTS server), not as something llama-server itself serves.

The real vocoder-related flags (\`--model-vocoder\`, \`--tts-use-guide-tokens\`) are still documented elsewhere and unchanged.

## Test plan
- [x] Confirmed via grep that neither flag string exists in arg.cpp or any \`.cpp\`/\`.h\` outside conversion scripts.
- [x] Confirmed only \`/v1/audio/transcriptions\` is registered (no \`/v1/audio/speech\`).
- [x] Other 22 documented endpoints all match actual routes (audit pass).
- [ ] (post-merge) markdown table renders cleanly on GitHub.

## Audit scope

Spot-checked 6 documented defaults (\`--ctx-checkpoints\`, \`--models-max\`, \`--cache-ram\`, \`--slot-prompt-similarity\`, \`--reasoning\`, \`--models-autoload\`) — all match \`common/common.h\` values. So no broader sweep needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)