### PR TITLE
fix(server): public endpoints stay public when --api-prefix is set

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -173,7 +173,7 @@ bool server_http_context::init(const common_params & params) {
     // Middlewares
     //
 
-    auto middleware_validate_api_key = [api_keys = params.api_keys](const httplib::Request & req, httplib::Response & res) {
+    auto middleware_validate_api_key = [api_keys = params.api_keys, api_prefix = path_prefix](const httplib::Request & req, httplib::Response & res) {
         static const std::unordered_set<std::string> public_endpoints = {
             "/health",
             "/v1/health",
@@ -190,8 +190,16 @@ bool server_http_context::init(const common_params & params) {
             return true;
         }
 
-        // If path is public or static file, skip validation
-        if (public_endpoints.find(req.path) != public_endpoints.end()) {
+        // If path is public or static file, skip validation. When --api-prefix
+        // is set, handlers are registered at prefix+path (see post/get below)
+        // so req.path arrives as e.g. "/llama/health" — strip the prefix
+        // before checking the allowlist so /llama/health is still public.
+        std::string check_path = req.path;
+        if (!api_prefix.empty() && check_path.size() >= api_prefix.size() &&
+            check_path.compare(0, api_prefix.size(), api_prefix) == 0) {
+            check_path.erase(0, api_prefix.size());
+        }
+        if (public_endpoints.find(check_path) != public_endpoints.end()) {
             return true;
         }
 

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -134,3 +134,32 @@ def test_local_media_file(media_path, image_url, success,):
         assert res.status_code == 200
     else:
         assert res.status_code == 400
+
+
+# Regression for the --api-prefix + public-endpoint allowlist bug: when
+# --api-prefix is set, handlers register at prefix+path so req.path arrives
+# as e.g. "/llama/health". The middleware used to compare req.path against
+# the un-prefixed allowlist and 401 it. Fix strips the prefix first.
+def test_api_prefix_keeps_public_endpoints_public():
+    server = ServerPreset.tinyllama2()
+    server.api_key = TEST_API_KEY
+    server.api_prefix = "/llama"
+    server.start()
+    for endpoint in ("/health", "/v1/models", "/", "/bundle.js"):
+        res = server.make_request("GET", "/llama" + endpoint)
+        assert res.status_code == 200, (
+            f"prefixed public endpoint {'/llama' + endpoint} should not require an api key, got {res.status_code}"
+        )
+
+
+def test_api_prefix_still_requires_key_for_private_routes():
+    # Same setup, but a private endpoint MUST still 401 without a key.
+    server = ServerPreset.tinyllama2()
+    server.api_key = TEST_API_KEY
+    server.api_prefix = "/llama"
+    server.start()
+    res = server.make_request("POST", "/llama/completions", data={
+        "prompt": "hello",
+    })
+    assert res.status_code == 401
+    assert res.body["error"]["type"] == "authentication_error"

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -86,6 +86,7 @@ class ServerProcess:
     server_slots: bool | None = False
     pooling: str | None = None
     api_key: str | None = None
+    api_prefix: str | None = None
     models_dir: str | None = None
     models_max: int | None = None
     models_preset: str | None = None
@@ -221,6 +222,8 @@ class ServerProcess:
             server_args.append("--context-shift")
         if self.api_key:
             server_args.extend(["--api-key", self.api_key])
+        if self.api_prefix:
+            server_args.extend(["--api-prefix", self.api_prefix])
         if self.spec_draft_n_max:
             server_args.extend(["--spec-draft-n-max", self.spec_draft_n_max])
         if self.spec_draft_n_min:
@@ -284,10 +287,11 @@ class ServerProcess:
         print(f"server pid={self.process.pid}, pytest pid={os.getpid()}")
 
         # wait for server to start
+        health_path = (self.api_prefix or "") + "/health"
         start_time = time.time()
         while time.time() - start_time < timeout_seconds:
             try:
-                response = self.make_request("GET", "/health", headers={
+                response = self.make_request("GET", health_path, headers={
                     "Authorization": f"Bearer {self.api_key}" if self.api_key else None
                 })
                 if response.status_code == 200:


### PR DESCRIPTION
## Summary

Bug-hunt round 4 on \`tools/server/server-http.cpp\`. The api-key middleware's allowlist for public endpoints (\`/health\`, \`/v1/health\`, \`/models\`, \`/v1/models\`, \`/\`, \`/index.html\`, \`/bundle.js\`, \`/bundle.css\`) matched against \`req.path\` verbatim. With \`--api-prefix /llama\`, the routes register at \`/llama/health\` etc. (handlers attach to \`path_prefix + path\` in \`server_http_context::{get,post}\`), so \`req.path\` arrives as \`/llama/health\` and never matches the un-prefixed allowlist — health probes and the static webui assets then 401 under \`--api-key\`, defeating the point of marking them public.

## Repro

\`\`\`sh
llama-server --api-key foo --api-prefix /llama --model tiny.gguf
curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/llama/health  # was 401, now 200
\`\`\`

## Fix

Capture \`path_prefix\` into the middleware lambda alongside \`api_keys\` and strip it from \`req.path\` before the allowlist lookup. Three-line change in the middleware, plus the obvious test fixture wiring (\`api_prefix\` field on \`ServerProcess\` + health-probe path adapts to the prefix).

## Test plan
- [x] \`test_api_prefix_keeps_public_endpoints_public\` — drives \`/llama/health\`, \`/llama/v1/models\`, \`/llama/\`, \`/llama/bundle.js\` with \`--api-key\` + \`--api-prefix /llama\` and asserts no 401.
- [x] \`test_api_prefix_still_requires_key_for_private_routes\` — guards the inverse: private endpoints under prefix MUST still 401 without a key.
- [x] All 20 security tests pass locally (was 18 before, my 2 added).
- [x] \`ServerProcess.start()\` health probe now uses \`(api_prefix or "") + "/health"\` so tests can actually use \`api_prefix\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)