### PR TITLE
docs(server): correct result-update names in README-dev request trace

### DIFF
--- a/tools/server/README-dev.md
+++ b/tools/server/README-dev.md
@@ -113,9 +113,9 @@ Here is an example trace of an API request for text completion:
 - `server_context` launches the task by moving it into an available slot (see `launch_slot_with_task()`).
 - `update_slot()` processes the task as described in the "Batching" section above.
 - Results may be sent using `send_partial_response` or `send_final_response`, which creates a new `server_task_result` and pushes it to the response queue.
-- At the same time, `server_res_generator` listens to the response queue and retrieves this response.
-- As the response is stateless, `server_res_generator` calls `response->update()` to update the response with the current state.
-- `server_res_generator` then calls `response->to_json()` and passes the response to the HTTP layer.
+- At the same time, `server_res_generator` listens to the response queue (via its `server_response_reader`) and retrieves each result.
+- As each `server_task_result` is itself stateless, `server_response_reader::next()` calls `result->update(states[idx])` to refresh the result with the cumulative generation state owned by the HTTP layer.
+- The HTTP layer then calls `result->to_json()` and sends the JSON to the client.
 
 ### Testing
 


### PR DESCRIPTION
## Summary

Epoch #86 task 2 (docs review round 2 on README-dev.md). The "Example trace of a request" section described \`response->update()\` and \`response->to_json()\`, neither of which exists by those names. The real calls are \`result->update(states[idx])\` (inside \`server_response_reader::next()\` at \`server-queue.cpp:396\`) and \`result->to_json()\` (various sites in \`server-context.cpp\` ~3854-3987).

A new contributor grepping for the names in the doc finds nothing. Three-line rewrite that uses the actual member names and threads the call sites through \`server_response_reader\` (which is what does both calls; \`server_res_generator\` owns the reader but doesn't call them directly).

## Audit scope

Spot-checked all named symbols in the doc — \`server_routes\`, \`server_res_generator\`, \`launch_slot_with_task\`, \`task_result_state\`, \`handle_completions_impl\` all exist by those names. Only the two method names were drifting.

## Test plan
- [x] grep confirms \`result->update(\` and \`result->to_json()\` exist at the documented call sites.
- [x] markdown renders (no shape changes, just text inside list items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)