### PR TITLE
chore(server): quiet benign Gemma4-Assistant memory-probe warning on MTP load

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -888,8 +888,19 @@ private:
                             has_draft ? "draft model" : "MTP context",
                             total / (1024.0 * 1024.0));
                 } catch (const std::exception & e) {
-                    SRV_WRN("[spec] failed to measure %s memory: %s\n",
-                            has_draft ? "draft model" : "MTP context", e.what());
+                    // Some arches (e.g. Gemma4Assistant) self-identify as "normal during
+                    // memory fitting" because their init requires ctx_other which can't
+                    // exist before the target is loaded. Downgrade those to DBG to avoid
+                    // a misleading "failed" warning on every load. See upstream TODO at
+                    // src/llama-context.cpp around the GEMMA4_ASSISTANT ctx_other check.
+                    const std::string msg = e.what();
+                    if (msg.find("normal during memory fitting") != std::string::npos) {
+                        SRV_DBG("[spec] skipping memory measurement of %s (benign): %s\n",
+                                has_draft ? "draft model" : "MTP context", e.what());
+                    } else {
+                        SRV_WRN("[spec] failed to measure %s memory: %s\n",
+                                has_draft ? "draft model" : "MTP context", e.what());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- The MTP draft memory-probe in `server-context.cpp` (~line 856) throws on Gemma4-Assistant because `cparams.ctx_other` is required and the target context doesn't exist yet at probe time.
- Upstream's own init explicitly notes "this is normal during memory fitting" in the exception message and carries a TODO to switch to a typed `llama_exception` so the warning can be skipped.
- Until that upstream change lands and flows in via a master sync, scan the exception message for the self-identifying "normal during memory fitting" marker and downgrade `SRV_WRN` -> `SRV_DBG` for that specific case. Real failures (model load failed, etc.) still surface as `SRV_WRN`.

## Why
- Eliminates the misleading `[spec] failed to measure draft model memory: failed to create llama_context from model` line that appears on every gemma-4-12b-qat-mtp pod start despite the model loading + running fine at ~110 tok/s (verified Phase 6 on titan, image `unified-llm:mtp-pr23398-5e6dff22`).
- The warning was non-blocking and we shipped γ around it, but it pollutes the logs every load and would lead to a future operator chasing a non-bug.

## Test plan
- [x] cmake build of llama-server still clean (CUDA on, all targets)
- [x] No behavior change for real failures (only downgrade when the exception self-identifies as benign-during-fit)
- [ ] Snoop verifies the warning is gone on the next titan pod restart (no roll/bake needed — just a logging change; we'll fold it into the next bake naturally)

## Related
- Source of the exception: `src/llama-context.cpp` near the `GEMMA4_ASSISTANT` `ctx_other` check (carries a TODO from am17an's upstream PR ggml-org/llama.cpp#23398 to switch to typed exception)
- γ master sync PR that brought the warning in: #93