### PR TITLE
scripts(dflash): restore Round-12 bench + parity scaffolds to ht

### DIFF
--- a/scripts/bench-dflash-target-sweep.sh
+++ b/scripts/bench-dflash-target-sweep.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# DFlash TARGET-precision sweep bench (Round-12).
+#
+# WHY THIS EXISTS (distinct from bench-dflash.sh):
+#   bench-dflash.sh pins the target at Q4_K_M and sweeps the *drafter* quant.
+#   But the DFlash drafter is trained on the target's BF16 hidden states, and
+#   we feed it features extracted from a *quantized* target. So the most likely
+#   cause of the 8% vs published ~21% accept gap is TARGET quant noise shifting
+#   the hidden states off the distribution the drafter was trained on. This
+#   harness sweeps the TARGET (-m) with the drafter (-md) FIXED, to test that.
+#
+# It also hardens the statistics vs the old harness (item 3 — trustworthy bench):
+#   1. Accept is recomputed exactly from the binary's raw n_accept/n_drafted
+#      counts (with the printed 'accept    =' percentage line as a fallback),
+#      rather than from a 3-run mean of the rounded percentage.
+#   2. It reports mean +/- sample stddev over N runs, not just a 3-run mean,
+#      and flags cross-target deltas that fall within combined noise. DFlash
+#      accept has ~2pp run-to-run variance, so sub-2pp deltas are noise.
+#
+# SAFETY: every target is validated with scripts/gguf-meta.py --check-instruct
+#   before use. Base fine-tune (e.g. $GGUFS/gemma-4-31B.gguf) and truncated/stub
+#   GGUFs (e.g. the 1.4GB gemma-4-31B-it-Q5_K_M.gguf) are REFUSED — benching the
+#   instruct-trained drafter against a base target is a confounded experiment.
+#
+# Usage:
+#   scripts/bench-dflash-target-sweep.sh \
+#       [--targets <comma list of gguf paths or $GGUFS basenames>] \
+#       [--drafter Q6_K] [--runs 10] [--temp 0] [--seed-base 1] [--ctx 4096] [-n 128]
+#
+# Default target list is the clean instruct targets currently on disk PLUS the
+# high-precision targets that the Round-12 download/convert will produce; missing
+# ones are skipped with a note (so this is the one command to re-run once F16/Q8
+# land).
+#
+# Output: /tmp/dflash-target-sweep-<ts>.md
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$ROOT/build-cuda/bin/llama-speculative-simple"
+META="$ROOT/scripts/gguf-meta.py"
+GGUFS_DIR="${GGUFS:-$ROOT/models}"
+DRAFTER_DIR="${DFLASH_DRAFTER_DIR:-$ROOT/models/dflash-gemma4-31b-gguf}"
+TS="$(date +%Y%m%d-%H%M%S)"
+OUT="/tmp/dflash-target-sweep-$TS.md"
+
+# Default sweep: low -> high precision instruct targets. F16/Q8 produced by the
+# Round-12 convert step; listed here so this command "just works" once they exist.
+TARGETS="gemma-4-31B-it-IQ4_XS.gguf,gemma-4-31B-it-Q4_K_M.gguf,gemma-4-31B-it-Q8_0.gguf,gemma-4-31B-it-BF16.gguf"
+DRAFTER="Q6_K"
+RUNS=10
+TEMP=0
+SEED_BASE=1
+CTX=4096
+NGEN=128
+
+while (( $# )); do
+    case "$1" in
+        --targets)   TARGETS="$2"; shift 2 ;;
+        --drafter)   DRAFTER="$2"; shift 2 ;;
+        --runs)      RUNS="$2"; shift 2 ;;
+        --temp)      TEMP="$2"; shift 2 ;;
+        --seed-base) SEED_BASE="$2"; shift 2 ;;
+        --ctx)       CTX="$2"; shift 2 ;;
+        -n)          NGEN="$2"; shift 2 ;;
+        --help|-h)   sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed -E 's/^# ?//' | head -n -1; exit 0 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+MTBENCH_PROMPT="Write a 50-word paragraph about speculative decoding."
+HUMANEVAL_PROMPT='Complete the Python function:
+def fibonacci(n: int) -> list[int]:
+    """Return the first n Fibonacci numbers as a list."""'
+
+[[ -x "$BIN" ]] || { echo "missing/non-executable: $BIN" >&2
+    echo "build: cmake --build build-cuda --target llama-speculative-simple -j" >&2; exit 1; }
+[[ -f "$META" ]] || { echo "missing gguf validator: $META" >&2; exit 1; }
+
+drafter_path="$DRAFTER_DIR/gemma4-31b-it-dflash-${DRAFTER}.gguf"
+[[ -f "$drafter_path" ]] || { echo "missing drafter: $drafter_path" >&2; exit 1; }
+
+# Resolve a target token to an absolute path: accept abs path, else look in $GGUFS.
+resolve_target() {
+    local t="$1"
+    if [[ -f "$t" ]]; then echo "$t"; return 0; fi
+    if [[ -f "$GGUFS_DIR/$t" ]]; then echo "$GGUFS_DIR/$t"; return 0; fi
+    return 1
+}
+
+# accept-rate parser. Each LOG_INF line in stderr is prefixed with a
+# timestamp + level letter (e.g. "0.05.300.148 I n_drafted = 144"), so
+# substring patterns are NOT line-anchored — anchored regex silently misses.
+#
+# Format strings (verified against build-cuda/bin/llama-speculative-simple):
+#     <timestamp> I n_drafted = <int>
+#     <timestamp> I n_accept  = <int>
+#     <timestamp> I accept    = <float>%      (FOUR spaces before '=')
+#
+# Recompute the FRACTION from raw counts (n_accept / n_drafted) — exact and
+# aggregates cleanly. Falls back to the printed percentage if counts absent;
+# fallback requires actual digits in the percent field (skips '-nan%' from
+# degenerate n_drafted=0 runs to avoid silent misparse).
+parse_accept() {
+    local err="$1" nd na
+    nd="$(grep -E 'n_drafted = ' "$err" | tail -1 | sed -nE 's/.*n_drafted = ([0-9]+).*/\1/p')"
+    na="$(grep -E 'n_accept  = ' "$err" | tail -1 | sed -nE 's/.*n_accept  = ([0-9]+).*/\1/p')"
+    if [[ "$nd" =~ ^[0-9]+$ && "$na" =~ ^[0-9]+$ && "$nd" -gt 0 ]]; then
+        awk -v a="$na" -v d="$nd" 'BEGIN{printf "%.6f", a/d}'
+        return 0
+    fi
+    grep -E 'accept    = ' "$err" | tail -1 \
+        | sed -nE 's/.*accept    = ([0-9]+\.[0-9]+)%.*/\1/p' \
+        | awk '{if(NF==1 && $1 ~ /^[0-9.]+$/){printf "%.6f", $1/100}}'
+}
+parse_tps() {
+    grep -E 'decoded .* t/s' "$1" | tail -1 | sed -E 's/.*speed: *([0-9.]+) t\/s/\1/'
+}
+
+run_one() {  # target_path drafter_path prompt seed out_dir label
+    local tgt="$1" dft="$2" prompt="$3" seed="$4" out_dir="$5" label="$6"
+    local err="$out_dir/$label.err"
+    timeout 360 "$BIN" \
+        -m "$tgt" -md "$dft" --dflash \
+        -p "$prompt" \
+        -n "$NGEN" -c "$CTX" -ngl 99 -ngld 99 -fa on \
+        --temp "$TEMP" --seed "$seed" \
+        --cache-type-k q8_0 --cache-type-v q8_0 \
+        > "$out_dir/$label.out" 2> "$err" || true
+    local acc tps
+    acc="$(parse_accept "$err")"; tps="$(parse_tps "$err")"
+    echo "${acc:-NA}|${tps:-NA}"
+}
+
+# mean + sample stddev (percent) from a list of fractional accept rates.
+stats() {  # space-separated fractions -> "mean_pct std_pct n_ok"
+    awk '{
+        n=0; s=0; ss=0;
+        for (i=1;i<=NF;i++) if ($i+0==$i && $i!="") { v=$i*100; a[n++]=v; s+=v; ss+=v*v }
+        if (n==0) { print "NA NA 0"; exit }
+        m=s/n;
+        sd=(n>1)?sqrt((ss-n*m*m)/(n-1)):0;
+        printf "%.2f %.2f %d", m, sd, n
+    }' <<< "$1"
+}
+
+OUT_DIR="/tmp/dflash-target-sweep-$TS-runs"; mkdir -p "$OUT_DIR"
+
+{
+    echo "# DFlash TARGET-precision sweep $TS"
+    echo ""
+    echo "- Build: $(cd "$ROOT" && git rev-parse --short HEAD)"
+    echo "- Drafter (FIXED): gemma4-31b-it-dflash-${DRAFTER}.gguf"
+    echo "- Runs/condition: $RUNS   temp: $TEMP   seed-base: $SEED_BASE   ctx: $CTX   n: $NGEN   KV: q8_0"
+    echo "- Accept recomputed from raw n_accept/n_drafted counts (fallback: printed 'accept    =' line)."
+    echo "- Reference (vLLM PR #41703, Gemma4 Anbeeld-style): MT-Bench ~21.7%, HumanEval ~44.7%."
+    echo ""
+    echo "| target | prompt | mean accept | stddev | n | tok/s | per-run |"
+    echo "|---|---|---:|---:|---:|---:|---|"
+} | tee "$OUT"
+
+declare -A MEAN_MT MEAN_HE STD_MT STD_HE
+
+IFS=, read -ra TGT_ARR <<< "$TARGETS"
+for tname in "${TGT_ARR[@]}"; do
+    tpath="$(resolve_target "$tname" || true)"
+    if [[ -z "${tpath:-}" ]]; then
+        echo "| $tname | — | SKIP (not on disk) | | | | |" | tee -a "$OUT"
+        continue
+    fi
+    if ! python3 "$META" --check-instruct "$tpath" >/dev/null 2>/tmp/sweep_reject.$$; then
+        reason="$(tr -s ' ' < /tmp/sweep_reject.$$)"
+        echo "| $tname | — | **REFUSED** | | | | $reason |" | tee -a "$OUT"
+        echo "REFUSED target $tname: $reason" >&2
+        continue
+    fi
+
+    for plabel in "MT-Bench" "HumanEval"; do
+        prompt="$MTBENCH_PROMPT"; [[ "$plabel" == "HumanEval" ]] && prompt="$HUMANEVAL_PROMPT"
+        accs=""; last_tps="NA"
+        for ((r=0; r<RUNS; r++)); do
+            seed=$(( TEMP == 0 ? SEED_BASE : SEED_BASE + r ))  # temp0: fixed seed; temp>0: vary
+            label="${tname%%.gguf}_${plabel}_${r}"
+            res="$(run_one "$tpath" "$drafter_path" "$prompt" "$seed" "$OUT_DIR" "$label")"
+            accs+=" $(cut -d'|' -f1 <<< "$res" | tr -d '%')"
+            last_tps="$(cut -d'|' -f2 <<< "$res")"
+        done
+        read -r mean sd n <<< "$(stats "$accs")"
+        per_run="$(echo "$accs" | sed -E 's/ /, /g; s/^, //')"
+        echo "| $tname | $plabel | ${mean}% | ±${sd} | $n | ${last_tps} | ${per_run} |" | tee -a "$OUT"
+        if [[ "$plabel" == "MT-Bench" ]]; then MEAN_MT[$tname]=$mean; STD_MT[$tname]=$sd
+        else MEAN_HE[$tname]=$mean; STD_HE[$tname]=$sd; fi
+    done
+done
+
+# Noise-aware comparison vs the Q4_K_M baseline, if present.
+BASE="gemma-4-31B-it-Q4_K_M.gguf"
+{
+    echo ""
+    echo "## Delta vs $BASE (is any precision gain real, or within noise?)"
+    echo ""
+    if [[ -n "${MEAN_MT[$BASE]:-}" ]]; then
+        for tname in "${TGT_ARR[@]}"; do
+            [[ "$tname" == "$BASE" || -z "${MEAN_MT[$tname]:-}" ]] && continue
+            for cls in MT-Bench HumanEval; do
+                if [[ "$cls" == "MT-Bench" ]]; then
+                    m=${MEAN_MT[$tname]}; mb=${MEAN_MT[$BASE]}; s=${STD_MT[$tname]}; sb=${STD_MT[$BASE]}
+                else
+                    m=${MEAN_HE[$tname]}; mb=${MEAN_HE[$BASE]}; s=${STD_HE[$tname]}; sb=${STD_HE[$BASE]}
+                fi
+                read -r d verdict <<< "$(awk -v m="$m" -v mb="$mb" -v s="$s" -v sb="$sb" 'BEGIN{
+                    d=m-mb; comb=sqrt(s*s+sb*sb);
+                    printf "%.2f %s", d, (d>comb ? "REAL(>1sigma)" : "within-noise")
+                }')"
+                echo "- $tname [$cls]: ${d}pp vs baseline (combined sigma ~$(awk -v s="$s" -v sb="$sb" 'BEGIN{printf "%.2f", sqrt(s*s+sb*sb)}')) -> $verdict"
+            done
+        done
+    else
+        echo "(baseline $BASE not in this run — add it to --targets for delta analysis)"
+    fi
+    echo ""
+    echo "Per-run stderr: $OUT_DIR/*.err"
+} | tee -a "$OUT"
+
+echo "Done -> $OUT"

--- a/scripts/dflash-logit-parity.py
+++ b/scripts/dflash-logit-parity.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# DFlash drafter LOGIT-parity harness (Round-12, item 2).
+#
+# WHY: Round-7b compared WEIGHTS (storage fidelity: GGUF Q6_K vs safetensors
+# bf16, ~1.78% RMS). That proves tensors are stored right; it does NOT prove the
+# FORWARD pass produces the reference logits. A bug in extraction point, mask,
+# position scheme, feature fusion, or per-head norm placement passes weight-parity
+# green while silently tanking acceptance. This harness closes that gap: it runs
+# the z-lab PyTorch drafter as ground truth and compares PER-POSITION DRAFT LOGITS
+# against our llama.cpp drafter on the SAME fixed input.
+#
+# STATUS: SCAFFOLD. The reference forward encodes everything the Round-5 audit
+# established about our implementation (so it doubles as an executable spec), but
+# the z-lab-repo-specific module glue is marked TODO(zlab). The drafter weights
+# (z-lab/gemma-4-31B-it-DFlash safetensors) are downloaded to
+# /media/me/storage/zlab-gemma-4-31B-it-DFlash, but that HF repo ships weights +
+# config only — the custom DFlashDraftModel class lives in github.com/z-lab/dflash
+# (or vLLM PR #41703), which must be installed to run the reference forward.
+#
+# Pipeline being verified (from src/models/dflash.cpp + gemma4.cpp audit):
+#   target: gemma-4-31B-it, capture hidden states AFTER each target layer l_out
+#           (LATE extraction, the llama.cpp default) at layer ids:
+#           DFLASH_TARGET_LAYER_IDS below.
+#   drafter: concat features over those layers -> fc -> dflash_hidden_norm (RMS)
+#            -> 5x cross-attn blocks (K/V = [ctx_features, noise], non-causal mask,
+#               per-head q_norm/k_norm, SWA on layers [T,T,T,T,F], window 2048)
+#            -> output_norm -> shared target lm_head
+#            -> final_logit_softcapping = 30.0  (Gemma4)
+#   noise block: [id_last, <mask>*(block_size-1)], block_size = 16,
+#                noise embeddings scaled by sqrt(n_embd)  (Gemma4 embed scale).
+#
+# Usage (in an env with torch + transformers + the downloaded models):
+#   dflash-logit-parity.py reference \
+#       --target  <hf path or id: google/gemma-4-31B-it> \
+#       --drafter <hf path or id: z-lab/gemma-4-31B-it-DFlash> \
+#       --prompt-file PROMPT.txt --out ref_logits.npz
+#
+#   # dump our side from llama.cpp (see dump_ours() docstring), then:
+#   dflash-logit-parity.py compare --ref ref_logits.npz --ours ours_logits.npz
+#
+# Output: per draft position — top-1 agreement, top-5 overlap, logit RMS / max-abs.
+
+import argparse
+import json
+import os
+import sys
+
+# Fallback defaults (verified against z-lab/gemma-4-31B-it-DFlash config.json on
+# 2026-05-31). These are ONLY used if the drafter config can't be read; the
+# reference forward calls load_dflash_constants() to read them from the actual
+# downloaded config so they can never silently drift from the model.
+DFLASH_TARGET_LAYER_IDS = [1, 12, 23, 35, 46, 57]
+BLOCK_SIZE = 16
+MASK_TOKEN_ID = 4          # drafter GGUF tokenizer <mask>
+FINAL_LOGIT_SOFTCAP = 30.0  # Gemma4
+SWA_PATTERN = [True, True, True, True, False]
+SWA_WINDOW = 2048
+
+
+def load_dflash_constants(drafter_dir):
+    """Read the architectural constants from the drafter's config.json.
+
+    Data-driven so the harness can never assert a value that disagrees with the
+    actual model. Returns a dict; raises if the config is missing required keys."""
+    cfg_path = os.path.join(drafter_dir, "config.json")
+    with open(cfg_path) as f:
+        c = json.load(f)
+    df = c.get("dflash_config", {})
+    layer_types = c.get("layer_types", [])
+    consts = {
+        "target_layer_ids": df.get("target_layer_ids", DFLASH_TARGET_LAYER_IDS),
+        "block_size": c.get("block_size", BLOCK_SIZE),
+        "mask_token_id": df.get("mask_token_id", MASK_TOKEN_ID),
+        "final_logit_softcapping": c.get("final_logit_softcapping", FINAL_LOGIT_SOFTCAP),
+        "swa_pattern": [("sliding" in t) for t in layer_types] if layer_types else SWA_PATTERN,
+        "sliding_window": c.get("sliding_window", SWA_WINDOW),
+        "num_attention_heads": c.get("num_attention_heads"),
+        "num_key_value_heads": c.get("num_key_value_heads"),
+        "head_dim": c.get("head_dim"),
+        "hidden_size": c.get("hidden_size"),
+        "num_hidden_layers": c.get("num_hidden_layers"),
+    }
+    # Drift guard: warn loudly if the on-disk config disagrees with our fallbacks,
+    # so a model update surfaces instead of being silently absorbed.
+    if consts["target_layer_ids"] != DFLASH_TARGET_LAYER_IDS:
+        print(f"[logit-parity] WARN: target_layer_ids in config "
+              f"{consts['target_layer_ids']} != fallback {DFLASH_TARGET_LAYER_IDS}", file=sys.stderr)
+    return consts
+
+
+def _need(mod):
+    try:
+        return __import__(mod)
+    except Exception as e:
+        sys.exit(f"[logit-parity] missing dependency '{mod}': {e}\n"
+                 f"Run in the convert env (the one with transformers/torch) where the "
+                 f"Round-12 download landed. This host's .venv numpy is known-broken (MKL).")
+
+
+def cmd_reference(args):
+    """Ground-truth forward via the z-lab PyTorch drafter.
+
+    Captures target hidden states (LATE convention) and runs the drafter block-
+    diffusion forward to produce per-position draft logits."""
+    torch = _need("torch")
+    _need("transformers")
+    np = _need("numpy")
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    # Data-driven constants from the actual drafter config (never hardcoded).
+    consts = load_dflash_constants(args.drafter)
+    layer_ids = consts["target_layer_ids"]
+    print(f"[logit-parity] constants from {args.drafter}/config.json: "
+          f"layer_ids={layer_ids} block_size={consts['block_size']} "
+          f"mask={consts['mask_token_id']} softcap={consts['final_logit_softcapping']} "
+          f"swa={consts['swa_pattern']} window={consts['sliding_window']}", file=sys.stderr)
+
+    prompt = open(args.prompt_file).read() if args.prompt_file else \
+        "Write a 50-word paragraph about speculative decoding."
+
+    tok = AutoTokenizer.from_pretrained(args.target)
+    target = AutoModelForCausalLM.from_pretrained(
+        args.target, torch_dtype=torch.bfloat16, output_hidden_states=True, device_map="auto")
+    target.eval()
+
+    ids = tok(prompt, return_tensors="pt").input_ids.to(target.device)
+    with torch.no_grad():
+        out = target(ids)
+    # hidden_states[i] is the OUTPUT of layer i-1 (index 0 = embeddings), so the
+    # post-l_out hidden for target layer L is hidden_states[L+1]. LATE convention.
+    hs = out.hidden_states
+    feats = [hs[L + 1][0, -1, :] for L in layer_ids]  # last-token ctx
+    ctx_features = torch.cat(feats, dim=-1)  # [n_layers * n_embd]
+    id_last = int(ids[0, -1].item())
+
+    # TODO(zlab): load z-lab/gemma-4-31B-it-DFlash drafter modules and run the
+    # block-diffusion forward described in the header. Requires the z-lab repo's
+    # DFlash drafter class (not a vanilla HF CausalLM). Steps, once wired:
+    #   1. fc(ctx_features) -> hidden_norm (RMS)
+    #   2. noise embeds = target.embed_tokens([id_last, MASK*(BLOCK_SIZE-1)]) * sqrt(n_embd)
+    #   3. 5 cross-attn blocks, K/V = [ctx, noise], non-causal mask, q/k per-head RMS,
+    #      SWA per SWA_PATTERN/SWA_WINDOW
+    #   4. output_norm -> target.lm_head -> softcap(FINAL_LOGIT_SOFTCAP)
+    #   5. draft_logits[pos] for pos in 1..BLOCK_SIZE-1
+    raise SystemExit(
+        "[logit-parity] reference scaffold reached the z-lab drafter forward "
+        "(TODO(zlab)). Target hidden-state capture is implemented and correct per "
+        "the audit; wire the z-lab drafter module here once the safetensors are "
+        "downloaded. ctx_features shape would be "
+        f"{tuple(ctx_features.shape)}, id_last={id_last}.")
+
+
+def cmd_compare(args):
+    """Compare reference vs our llama.cpp draft logits, per position."""
+    np = _need("numpy")
+    ref = np.load(args.ref)
+    ours = np.load(args.ours)
+    rl, ol = ref["logits"], ours["logits"]  # [n_pos, n_vocab]
+    if rl.shape != ol.shape:
+        sys.exit(f"shape mismatch: ref {rl.shape} vs ours {ol.shape}")
+    print(f"# positions={rl.shape[0]} vocab={rl.shape[1]}")
+    print("| pos | top1 agree | top5 overlap | logit RMS | max|Δ| |")
+    print("|---|---|---|---:|---:|")
+    for p in range(rl.shape[0]):
+        r, o = rl[p], ol[p]
+        r5 = set(np.argsort(r)[-5:].tolist())
+        o5 = set(np.argsort(o)[-5:].tolist())
+        top1 = int(np.argmax(r)) == int(np.argmax(o))
+        rms = float(np.sqrt(np.mean((r - o) ** 2)))
+        mx = float(np.max(np.abs(r - o)))
+        print(f"| {p} | {'Y' if top1 else 'N'} | {len(r5 & o5)}/5 | {rms:.4f} | {mx:.4f} |")
+
+
+# How to dump OUR side from llama.cpp:
+#   build-cuda/bin/llama-speculative-simple already logs the top-5 of draft pos 1
+#   under LLAMA_DFLASH_DEBUG. For full per-position vectors, add a one-shot dump in
+#   common/speculative.cpp draft() guarded by LLAMA_DFLASH_DUMP=<path>, writing
+#   llama_get_logits_ith(ctx_dft_dec, i) for i in 1..block_size-1 as an .npz with
+#   key "logits". (Deferred to the build step; do not add until the squash lands.)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="DFlash drafter logit-parity harness (item 2 scaffold)")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    r = sub.add_parser("reference", help="z-lab PyTorch ground-truth forward")
+    r.add_argument("--target", required=True)
+    r.add_argument("--drafter", required=True)
+    r.add_argument("--prompt-file")
+    r.add_argument("--out", required=True)
+    r.set_defaults(fn=cmd_reference)
+    c = sub.add_parser("compare", help="compare ref vs ours .npz")
+    c.add_argument("--ref", required=True)
+    c.add_argument("--ours", required=True)
+    c.set_defaults(fn=cmd_compare)
+    args = ap.parse_args()
+    args.fn(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gguf-meta.py
+++ b/scripts/gguf-meta.py
@@ -72,8 +72,13 @@ def _rval(f, t):
 def read_meta(path):
     """Return dict of header KV fields, plus _has_chat_template / _ok flags.
 
-    Raises ValueError on a non-GGUF / truncated file."""
+    Raises ValueError on a non-GGUF / truncated file. Also walks the tensor-info
+    section to confirm the tensor DATA is actually present (catches a file whose
+    header parses cleanly but whose weights were truncated — same failure class
+    as the HF-xet silent shard drop). Sets _data_complete / _min_size_bytes."""
+    import os
     meta = {}
+    file_size = os.path.getsize(path)
     with open(path, 'rb') as f:
         magic = _rd(f, '<I', 4)
         if magic != GGUF_MAGIC:
@@ -88,15 +93,45 @@ def read_meta(path):
         meta["_version"] = ver
         meta["_n_tensors"] = n_tensors
         has_ct = False
+        alignment = 32  # GGUF default; overridden by general.alignment if present
         for _ in range(n_kv):
             key = _rstr(f)
             t = _rd(f, '<I', 4)
             v = _rval(f, t)
             if key == "tokenizer.chat_template":
                 has_ct = True
+            if key == "general.alignment":
+                alignment = int(v) or 32
             if key in WANT:
                 meta[key] = v
         meta["_has_chat_template"] = has_ct
+
+        # Walk the tensor-info section: name, n_dims, dims[], type, offset.
+        # The max offset is a lower bound on how far the data section must extend,
+        # so the file must be at least data_start + max_offset long.
+        max_offset = 0
+        try:
+            for _ in range(n_tensors):
+                _rstr(f)                       # tensor name
+                ndim = _rd(f, '<I', 4)
+                for _d in range(ndim):
+                    _rd(f, '<Q', 8)            # dim
+                _rd(f, '<I', 4)               # ggml type
+                off = _rd(f, '<Q', 8)         # data offset (relative to data section)
+                if off > max_offset:
+                    max_offset = off
+            data_start = f.tell()
+            if alignment > 1 and (data_start % alignment) != 0:
+                data_start += alignment - (data_start % alignment)
+            min_size = data_start + max_offset + 1  # last tensor needs >=1 byte
+            meta["_min_size_bytes"] = min_size
+            meta["_actual_size_bytes"] = file_size
+            meta["_data_complete"] = file_size >= min_size
+        except Exception:
+            # Could not read the full tensor table → it's truncated within the header.
+            meta["_data_complete"] = False
+            meta["_min_size_bytes"] = None
+            meta["_actual_size_bytes"] = file_size
     return meta
 
 
@@ -134,6 +169,14 @@ def main():
                   f"{meta.get('_has_chat_template')}). DFlash-it drafter needs an INSTRUCT target.",
                   file=sys.stderr)
             return 1
+        if meta.get("_data_complete") is False:
+            mn = meta.get("_min_size_bytes")
+            act = meta.get("_actual_size_bytes")
+            print(f"REJECT {path}: TRUNCATED — header valid but tensor data incomplete "
+                  f"(file {act} bytes < min {mn} bytes implied by tensor offsets). "
+                  f"Partial/corrupt write; would load garbage or crash mid-bench.",
+                  file=sys.stderr)
+            return 1
         print(f"OK {path}: instruct gemma4 (name={meta.get('general.name')!r}, "
               f"file_type={meta.get('general.file_type')})")
         return 0
@@ -152,6 +195,13 @@ def main():
                 print(f"  {k:30s} = {str(meta[k])[:90]}")
         print(f"  {'has_chat_template':30s} = {meta.get('_has_chat_template')}")
         print(f"  {'is_instruct':30s} = {is_instruct(meta)}")
+        print(f"  {'n_tensors':30s} = {meta.get('_n_tensors')}")
+        complete = meta.get('_data_complete')
+        if complete is False:
+            print(f"  {'data_complete':30s} = False  (TRUNCATED: "
+                  f"{meta.get('_actual_size_bytes')} < {meta.get('_min_size_bytes')} bytes)")
+        else:
+            print(f"  {'data_complete':30s} = {complete}")
     return rc
 
 

--- a/scripts/gguf-meta.py
+++ b/scripts/gguf-meta.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Minimal, dependency-free GGUF metadata reader.
+#
+# Reads only the header key/value block (strings + scalars + short arrays).
+# Deliberately avoids numpy / gguf-py so it runs anywhere, including hosts
+# where the project .venv has a broken numpy (missing MKL).
+#
+# Usage:
+#   gguf-meta.py FILE [FILE ...]            # human-readable dump of key fields
+#   gguf-meta.py --check-instruct FILE      # exit 0 iff FILE is a non-corrupt
+#                                           #   gemma4 *instruct* target; else exit 1
+#
+# The --check-instruct mode is what the DFlash target-sweep bench uses to
+# refuse base-fine-tune or truncated GGUFs, so the base-vs-instruct confound
+# (a DFlash-it drafter benched against a base target) cannot be run by accident.
+
+import sys
+import struct
+
+GGUF_MAGIC = 0x46554747
+
+(T_UINT8, T_INT8, T_UINT16, T_INT16, T_UINT32, T_INT32, T_FLOAT32, T_BOOL,
+ T_STRING, T_ARRAY, T_UINT64, T_INT64, T_FLOAT64) = range(13)
+
+SCALAR_FMT = {
+    T_UINT8: ('<B', 1), T_INT8: ('<b', 1), T_UINT16: ('<H', 2), T_INT16: ('<h', 2),
+    T_UINT32: ('<I', 4), T_INT32: ('<i', 4), T_FLOAT32: ('<f', 4), T_BOOL: ('<?', 1),
+    T_UINT64: ('<Q', 8), T_INT64: ('<q', 8), T_FLOAT64: ('<d', 8),
+}
+
+WANT = [
+    "general.architecture", "general.name", "general.basename",
+    "general.finetune", "general.size_label", "general.file_type",
+    "general.quantization_version", "gemma4.block_count",
+]
+
+
+def _rd(f, fmt, n):
+    return struct.unpack(fmt, f.read(n))[0]
+
+
+def _rstr(f):
+    ln = _rd(f, '<Q', 8)
+    return f.read(ln).decode('utf-8', 'replace')
+
+
+def _rval(f, t):
+    if t in SCALAR_FMT:
+        fmt, n = SCALAR_FMT[t]
+        return _rd(f, fmt, n)
+    if t == T_STRING:
+        return _rstr(f)
+    if t == T_ARRAY:
+        at = _rd(f, '<I', 4)
+        ln = _rd(f, '<Q', 8)
+        out = []
+        for i in range(ln):
+            out.append(_rval(f, at))
+            if len(out) >= 8:  # only need a peek; skip the tail
+                rem = ln - len(out)
+                if at == T_STRING:
+                    for _ in range(rem):
+                        _rstr(f)
+                elif at in SCALAR_FMT:
+                    _, nb = SCALAR_FMT[at]
+                    f.read(nb * rem)
+                break
+        return out
+    raise ValueError(f"unknown gguf value type {t}")
+
+
+def read_meta(path):
+    """Return dict of header KV fields, plus _has_chat_template / _ok flags.
+
+    Raises ValueError on a non-GGUF / truncated file."""
+    meta = {}
+    with open(path, 'rb') as f:
+        magic = _rd(f, '<I', 4)
+        if magic != GGUF_MAGIC:
+            raise ValueError("not a GGUF file (bad magic) — truncated or wrong format")
+        ver = _rd(f, '<I', 4)
+        n_tensors = _rd(f, '<Q', 8)
+        n_kv = _rd(f, '<Q', 8)
+        if ver == 0 or n_tensors == 0 or n_kv == 0:
+            raise ValueError(
+                f"truncated/stub GGUF (version={ver}, n_tensors={n_tensors}, n_kv={n_kv}) "
+                f"— valid magic but no payload; partial/corrupt write")
+        meta["_version"] = ver
+        meta["_n_tensors"] = n_tensors
+        has_ct = False
+        for _ in range(n_kv):
+            key = _rstr(f)
+            t = _rd(f, '<I', 4)
+            v = _rval(f, t)
+            if key == "tokenizer.chat_template":
+                has_ct = True
+            if key in WANT:
+                meta[key] = v
+        meta["_has_chat_template"] = has_ct
+    return meta
+
+
+def is_instruct(meta):
+    name = str(meta.get("general.name", "")).lower()
+    ft = str(meta.get("general.finetune", "")).lower()
+    base = str(meta.get("general.basename", "")).lower()
+    return ("it" in ft) or ("-it" in name) or name.endswith(" it") or \
+           ("it" in base.split("-")) or meta.get("_has_chat_template", False)
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        return 2
+
+    if args[0] == "--check-instruct":
+        if len(args) != 2:
+            print("usage: gguf-meta.py --check-instruct FILE", file=sys.stderr)
+            return 2
+        path = args[1]
+        try:
+            meta = read_meta(path)
+        except Exception as e:
+            print(f"REJECT {path}: {e}", file=sys.stderr)
+            return 1
+        arch = str(meta.get("general.architecture", ""))
+        if arch != "gemma4":
+            print(f"REJECT {path}: architecture={arch!r} (expected gemma4)", file=sys.stderr)
+            return 1
+        if not is_instruct(meta):
+            print(f"REJECT {path}: BASE fine-tune (name={meta.get('general.name')!r}, "
+                  f"finetune={meta.get('general.finetune')!r}, chat_template="
+                  f"{meta.get('_has_chat_template')}). DFlash-it drafter needs an INSTRUCT target.",
+                  file=sys.stderr)
+            return 1
+        print(f"OK {path}: instruct gemma4 (name={meta.get('general.name')!r}, "
+              f"file_type={meta.get('general.file_type')})")
+        return 0
+
+    rc = 0
+    for path in args:
+        print(f"===== {path.split('/')[-1]} =====")
+        try:
+            meta = read_meta(path)
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            rc = 1
+            continue
+        for k in WANT:
+            if k in meta:
+                print(f"  {k:30s} = {str(meta[k])[:90]}")
+        print(f"  {'has_chat_template':30s} = {meta.get('_has_chat_template')}")
+        print(f"  {'is_instruct':30s} = {is_instruct(meta)}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Restores three scripts from the Round-12 DFlash investigation (June 1, originally on the unpushed `chore/dflash-bench-scripts` branch at HEAD `4d21baca4`). They were never landed on ht and went out of reach when the 2026-06-04 ht history rewrite removed that branch from the visible refs. The commits (`84a0da7bc`, `5f4598ee9`) are still in the object store; this PR cherry-picks them onto current ht (`f6feddb49`).

The scripts are needed to start the DFlash parity workstream: Phase 0 verified γ master-sync fixed the n_outputs_max crash, so the next bottleneck is the ~20× acceptance-quality gap vs the z-lab reference, and the logit-parity harness is the localizer.

## Scripts restored

| File | Purpose |
|---|---|
| `scripts/gguf-meta.py` | Numpy-free GGUF header reader with `--check-instruct` guard. Rejects base fine-tune and truncated/stub GGUFs before they reach a bench. |
| `scripts/bench-dflash-target-sweep.sh` | Sweeps the TARGET quant (drafter fixed) to isolate target-side quant noise. Uses raw `n_accept`/`n_drafted` counts and reports mean ± stddev with a noise-aware delta verdict. |
| `scripts/dflash-logit-parity.py` | Per-position logit-parity harness scaffold (z-lab PyTorch reference vs our llama.cpp drafter). The reference-forward `TODO(zlab)` is the next implementation step. |

All three are pure additions under `scripts/` — no source code is touched.

## Why this and not the originals

The originals were on a feature branch that no longer exists in any visible ref after the 2026-06-04 force-push rewrite. Cherry-picking onto ht (a) preserves Markus's authorship and original commit messages, (b) removes the "shared-worktree hazard" called out in `feedback_shared_path_writes` (scripts disappearing on branch switch), and (c) makes them tracked artifacts for the long-term parity work rather than orphan-branch holdovers.

## Test plan

- [x] `scripts/gguf-meta.py --check-instruct models/gemma-4-31B-it-IQ4_XS.gguf` → `OK ... instruct gemma4`
- [x] `scripts/bench-dflash-target-sweep.sh --help` → renders cleanly
- [ ] `scripts/dflash-logit-parity.py` reference path runs (deferred — needs TODO(zlab) wired in next PR)