### PR TITLE
scripts(dflash): deployment-parity prompt suite + bench harness

### DIFF
--- a/scripts/bench-dflash-parity.sh
+++ b/scripts/bench-dflash-parity.sh
@@ -19,6 +19,14 @@
 #   DFLASH_PARITY_DRAFTER    default: models/dflash-gemma4-31b-gguf/gemma4-31b-it-dflash-Q6_K.gguf
 #   DFLASH_PARITY_PROMPTS    default: scripts/dflash-parity-prompts.json
 #   DFLASH_PARITY_BIN        default: build/bin/llama-speculative-simple
+#   DFLASH_PARITY_NGL        target -ngl,  default 99 (lower for CPU-offload of large targets)
+#   DFLASH_PARITY_NGLD       drafter -ngld, default 99
+#   DFLASH_PARITY_TIMEOUT    per-prompt timeout in seconds, default 240 (raise for CPU-offload)
+#   DFLASH_PARITY_THREADS    --threads cap; default unset (llama.cpp picks). On centurion (etcd
+#                            HA control-plane member), cap to leave >=2 cores free for etcd/apiserver
+#                            (e.g. 6 on the 8-core 7800X3D) so long CPU-offload runs don't wobble
+#                            control-plane health.
+#   DFLASH_PARITY_NICE       0-19; default 0 (no renice). Set to 19 on centurion long runs.
 #
 # Output (stdout + --out):
 #   {
@@ -45,6 +53,13 @@ BIN="${DFLASH_PARITY_BIN:-$ROOT/build/bin/llama-speculative-simple}"
 TARGET="${DFLASH_PARITY_TARGET:-$ROOT/models/gemma-4-31B-it-IQ4_XS.gguf}"
 DRAFTER="${DFLASH_PARITY_DRAFTER:-$ROOT/models/dflash-gemma4-31b-gguf/gemma4-31b-it-dflash-Q6_K.gguf}"
 PROMPTS="${DFLASH_PARITY_PROMPTS:-$ROOT/scripts/dflash-parity-prompts.json}"
+NGL="${DFLASH_PARITY_NGL:-99}"
+NGLD="${DFLASH_PARITY_NGLD:-99}"
+PROMPT_TIMEOUT="${DFLASH_PARITY_TIMEOUT:-240}"
+THREADS_ARG=()
+[[ -n "${DFLASH_PARITY_THREADS:-}" ]] && THREADS_ARG=(--threads "$DFLASH_PARITY_THREADS")
+NICE_PREFIX=()
+[[ -n "${DFLASH_PARITY_NICE:-}" && "$DFLASH_PARITY_NICE" -gt 0 ]] && NICE_PREFIX=(nice -n "$DFLASH_PARITY_NICE")
 OUT="/tmp/dflash-parity-$(date +%Y%m%d-%H%M%S).json"
 
 while (( $# )); do
@@ -92,12 +107,13 @@ for i in $(seq 0 $((N_PROMPTS - 1))); do
     n_predict=$(tokens_for_class "$class")
     err="$ERRDIR/$id.err"
 
-    echo "[bench] $id ($class) n_predict=$n_predict" >&2
-    timeout 240 "$BIN" \
+    echo "[bench] $id ($class) n_predict=$n_predict ngl=$NGL ngld=$NGLD${DFLASH_PARITY_THREADS:+ threads=$DFLASH_PARITY_THREADS}${DFLASH_PARITY_NICE:+ nice=$DFLASH_PARITY_NICE}" >&2
+    timeout "$PROMPT_TIMEOUT" "${NICE_PREFIX[@]}" "$BIN" \
         -m "$TARGET" -md "$DRAFTER" \
         --dflash --spec-draft-n-max "$N_MAX" \
         -p "$text" -n "$n_predict" \
-        -c 8192 -ngl 99 -ngld 99 -fa on \
+        -c 8192 -ngl "$NGL" -ngld "$NGLD" -fa on \
+        "${THREADS_ARG[@]}" \
         --temp 0 --seed 1 \
         --cache-type-k q8_0 --cache-type-v q8_0 \
         > /dev/null 2> "$err" || true

--- a/scripts/bench-dflash-parity.sh
+++ b/scripts/bench-dflash-parity.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# DFlash deployment-parity bench harness.
+#
+# Runs scripts/dflash-parity-prompts.json against llama-speculative-simple and
+# emits per-prompt acceptance stats (tau, n_accept, n_drafted, decode_t/s) as
+# JSON. snoop-kube runs the SAME prompts against vLLM/SGLang with
+# z-lab/gemma-4-31B-it-DFlash on titan and emits the same JSON shape, so the
+# two outputs can be diffed cell-by-cell.
+#
+# Apples-to-apples: greedy temp=0, --spec-draft-n-max = block_size - 1 = 15,
+# fixed seed, --fa on. Target/drafter chosen via env (defaults to local Q-quant
+# pair so it runs in 24 GB; titan should override with BF16 target).
+#
+# Usage:
+#   scripts/bench-dflash-parity.sh [--out <file>]
+#
+# Env:
+#   DFLASH_PARITY_TARGET     default: models/gemma-4-31B-it-IQ4_XS.gguf
+#   DFLASH_PARITY_DRAFTER    default: models/dflash-gemma4-31b-gguf/gemma4-31b-it-dflash-Q6_K.gguf
+#   DFLASH_PARITY_PROMPTS    default: scripts/dflash-parity-prompts.json
+#   DFLASH_PARITY_BIN        default: build/bin/llama-speculative-simple
+#
+# Output (stdout + --out):
+#   {
+#     "build": "f6feddb49",
+#     "target": "gemma-4-31B-it-IQ4_XS.gguf",
+#     "drafter": "gemma4-31b-it-dflash-Q6_K.gguf",
+#     "block_size": 16,
+#     "spec_draft_n_max": 15,
+#     "temp": 0.0,
+#     "results": [
+#       { "id": "...", "class": "mt_bench",
+#         "n_predict": 33, "n_drafted": 480, "n_accept": 4,
+#         "tau": 1.1379, "decode_tps": 18.7 },
+#       ...
+#     ]
+#   }
+# tau is computed as n_predict / (n_predict - n_accept), the same convention
+# the z-lab reference reports.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${DFLASH_PARITY_BIN:-$ROOT/build/bin/llama-speculative-simple}"
+TARGET="${DFLASH_PARITY_TARGET:-$ROOT/models/gemma-4-31B-it-IQ4_XS.gguf}"
+DRAFTER="${DFLASH_PARITY_DRAFTER:-$ROOT/models/dflash-gemma4-31b-gguf/gemma4-31b-it-dflash-Q6_K.gguf}"
+PROMPTS="${DFLASH_PARITY_PROMPTS:-$ROOT/scripts/dflash-parity-prompts.json}"
+OUT="/tmp/dflash-parity-$(date +%Y%m%d-%H%M%S).json"
+
+while (( $# )); do
+    case "$1" in
+        --out) OUT="$2"; shift 2 ;;
+        --help|-h)
+            sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed -E 's/^# ?//' | head -n -1
+            exit 0 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+for f in "$BIN" "$TARGET" "$DRAFTER" "$PROMPTS"; do
+    [[ -e "$f" ]] || { echo "missing: $f" >&2; exit 1; }
+done
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+
+BUILD=$(cd "$ROOT" && git rev-parse --short HEAD)
+BLOCK=$(jq -r '.block_size' "$PROMPTS")
+N_MAX=$(jq -r '.spec_draft_n_max' "$PROMPTS")
+N_PROMPTS=$(jq -r '.prompts | length' "$PROMPTS")
+
+mt_bench_tokens=$(jq -r '.max_new_tokens_per_class.mt_bench' "$PROMPTS")
+humaneval_tokens=$(jq -r '.max_new_tokens_per_class.humaneval' "$PROMPTS")
+gsm8k_tokens=$(jq -r '.max_new_tokens_per_class.gsm8k' "$PROMPTS")
+
+tokens_for_class() {
+    case "$1" in
+        mt_bench)   echo "$mt_bench_tokens" ;;
+        humaneval)  echo "$humaneval_tokens" ;;
+        gsm8k)      echo "$gsm8k_tokens" ;;
+        *)          echo 128 ;;
+    esac
+}
+
+ERRDIR="${OUT%.json}-stderr"
+mkdir -p "$ERRDIR"
+
+results_json="[]"
+for i in $(seq 0 $((N_PROMPTS - 1))); do
+    id=$(jq -r ".prompts[$i].id" "$PROMPTS")
+    class=$(jq -r ".prompts[$i].class" "$PROMPTS")
+    text=$(jq -r ".prompts[$i].text" "$PROMPTS")
+    n_predict=$(tokens_for_class "$class")
+    err="$ERRDIR/$id.err"
+
+    echo "[bench] $id ($class) n_predict=$n_predict" >&2
+    timeout 240 "$BIN" \
+        -m "$TARGET" -md "$DRAFTER" \
+        --dflash --spec-draft-n-max "$N_MAX" \
+        -p "$text" -n "$n_predict" \
+        -c 8192 -ngl 99 -ngld 99 -fa on \
+        --temp 0 --seed 1 \
+        --cache-type-k q8_0 --cache-type-v q8_0 \
+        > /dev/null 2> "$err" || true
+
+    n_drafted=$(grep -E 'n_drafted\s*=' "$err" | tail -1 | awk -F'=' '{print $2}' | tr -d ' ')
+    n_accept=$(grep -E 'n_accept\s*=' "$err"  | tail -1 | awk -F'=' '{print $2}' | tr -d ' ')
+    decoded_line=$(grep -E 'decoded\s+[0-9]+\s+tokens' "$err" | tail -1)
+    n_pred=$(echo "$decoded_line" | awk '{print $(NF-7)}')
+    decode_tps=$(echo "$decoded_line" | awk '{print $(NF-1)}')
+
+    if [[ -z "${n_drafted:-}" || -z "${n_accept:-}" || -z "${n_pred:-}" ]]; then
+        echo "[bench] $id: failed to parse counters (see $err)" >&2
+        cell=$(jq -n --arg id "$id" --arg class "$class" \
+            '{id:$id, class:$class, error:"parse_failed"}')
+    else
+        tau=$(awk -v p="$n_pred" -v a="$n_accept" 'BEGIN{ d=p-a; if (d<=0) print "inf"; else printf "%.4f", p/d }')
+        cell=$(jq -n --arg id "$id" --arg class "$class" \
+            --argjson npred  "$n_pred" \
+            --argjson ndraft "$n_drafted" \
+            --argjson nacc   "$n_accept" \
+            --arg     tau    "$tau" \
+            --arg     tps    "$decode_tps" \
+            '{id:$id, class:$class, n_predict:$npred, n_drafted:$ndraft, n_accept:$nacc, tau:($tau|tonumber? // null), decode_tps:($tps|tonumber? // null)}')
+    fi
+    results_json=$(echo "$results_json" | jq --argjson c "$cell" '. + [$c]')
+done
+
+jq -n \
+    --arg build "$BUILD" \
+    --arg target "$(basename "$TARGET")" \
+    --arg drafter "$(basename "$DRAFTER")" \
+    --argjson block "$BLOCK" \
+    --argjson nmax  "$N_MAX" \
+    --argjson results "$results_json" \
+    '{build:$build, target:$target, drafter:$drafter, block_size:$block, spec_draft_n_max:$nmax, temp:0.0, results:$results}' \
+    | tee "$OUT"
+
+echo "[bench] wrote $OUT (stderr per-prompt at $ERRDIR/)" >&2

--- a/scripts/dflash-parity-prompts.json
+++ b/scripts/dflash-parity-prompts.json
@@ -1,0 +1,28 @@
+{
+  "_": "DFlash deployment-parity prompt suite. Greedy temp=0, max_new_tokens=128 (MT-Bench) / 256 (code+math).",
+  "_": "Same set runs on llama.cpp (scripts/bench-dflash-parity.sh) AND on vLLM/SGLang reference (snoop-kube).",
+  "_": "z-lab's published Gemma τ (conc=1, block=16, BF16): MT-Bench 4.23, HumanEval 8.00, GSM8K 7.53, MBPP 6.13, Math500 8.59.",
+  "_": "We use 5 representative prompts per class for statistical signal without bench-time blowup.",
+  "max_new_tokens_per_class": { "mt_bench": 128, "humaneval": 256, "gsm8k": 256 },
+  "block_size": 16,
+  "spec_draft_n_max": 15,
+  "prompts": [
+    { "id": "mt_bench_001", "class": "mt_bench", "text": "Compose an engaging travel blog post about a recent trip to Hawaii, highlighting cultural experiences and must-see attractions." },
+    { "id": "mt_bench_002", "class": "mt_bench", "text": "Draft a professional email seeking your supervisor's feedback on the 'Quarterly Financial Report' you prepared. Ask specifically about the data analysis, presentation style, and the clarity of conclusions drawn." },
+    { "id": "mt_bench_003", "class": "mt_bench", "text": "Imagine you are writing a blog post comparing two popular smartphone models. Develop an outline for the blog post, including key points and subheadings to effectively compare and contrast the features, performance, and user experience of the two models." },
+    { "id": "mt_bench_004", "class": "mt_bench", "text": "Pretend yourself to be Elon Musk in all the following conversations. Speak like Elon Musk as much as possible. Why do we need to go to Mars?" },
+    { "id": "mt_bench_005", "class": "mt_bench", "text": "Write a 50-word paragraph about speculative decoding." },
+
+    { "id": "humaneval_001", "class": "humaneval", "text": "Complete the Python function:\n\nfrom typing import List\n\ndef has_close_elements(numbers: List[float], threshold: float) -> bool:\n    \"\"\" Check if in given list of numbers, are any two numbers closer to each other than\n    given threshold.\n    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)\n    False\n    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)\n    True\n    \"\"\"\n" },
+    { "id": "humaneval_002", "class": "humaneval", "text": "Complete the Python function:\n\ndef fibonacci(n: int) -> list[int]:\n    \"\"\"Return the first n Fibonacci numbers as a list.\n    >>> fibonacci(0)\n    []\n    >>> fibonacci(5)\n    [0, 1, 1, 2, 3]\n    \"\"\"\n" },
+    { "id": "humaneval_003", "class": "humaneval", "text": "Complete the Python function:\n\ndef is_palindrome(s: str) -> bool:\n    \"\"\"Return True if the string s is a palindrome (ignoring case and non-alphanumerics).\n    >>> is_palindrome(\"A man, a plan, a canal: Panama\")\n    True\n    >>> is_palindrome(\"race a car\")\n    False\n    \"\"\"\n" },
+    { "id": "humaneval_004", "class": "humaneval", "text": "Complete the Python function:\n\ndef merge_sorted(a: list[int], b: list[int]) -> list[int]:\n    \"\"\"Merge two sorted lists into a single sorted list in O(len(a)+len(b)).\n    >>> merge_sorted([1, 3, 5], [2, 4, 6])\n    [1, 2, 3, 4, 5, 6]\n    \"\"\"\n" },
+    { "id": "humaneval_005", "class": "humaneval", "text": "Complete the Python function:\n\ndef count_vowels(s: str) -> int:\n    \"\"\"Return the number of vowels (a, e, i, o, u, case-insensitive) in s.\n    >>> count_vowels(\"Hello, World!\")\n    3\n    \"\"\"\n" },
+
+    { "id": "gsm8k_001", "class": "gsm8k", "text": "Question: Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?\nAnswer: Let's think step by step.\n" },
+    { "id": "gsm8k_002", "class": "gsm8k", "text": "Question: Weng earns $12 an hour for babysitting. Yesterday, she just did 50 minutes of babysitting. How much did she earn?\nAnswer: Let's think step by step.\n" },
+    { "id": "gsm8k_003", "class": "gsm8k", "text": "Question: Betty is saving money for a new wallet which costs $100. Betty has only half of the money she needs. Her parents decided to give her $15 for that purpose, and her grandparents twice as much as her parents. How much more money does Betty need to buy the wallet?\nAnswer: Let's think step by step.\n" },
+    { "id": "gsm8k_004", "class": "gsm8k", "text": "Question: Julie is reading a 120-page book. Yesterday, she was able to read 12 pages and today, she read twice as many pages as yesterday. If she wants to read half of the remaining pages tomorrow, how many pages should she read?\nAnswer: Let's think step by step.\n" },
+    { "id": "gsm8k_005", "class": "gsm8k", "text": "Question: James writes a 3-page letter to 2 different friends twice a week. How many pages does he write a year?\nAnswer: Let's think step by step.\n" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a deployment-parity prompt suite + bench harness so we can run the SAME prompt set on (a) our llama.cpp DFlash and (b) z-lab's reference (vLLM/SGLang) on titan and diff τ cell-by-cell.

Phase 0 verified γ master-sync fixed the n_outputs_max crash; DFlash now runs without crashing on current ht. Phase 1 (PR #97) restored the Round-12 scripts. Phase 2 (this PR) sets up the deployment-parity infrastructure — Markus chose this path over local logit-parity because it validates the reported metrics directly and snoop-kube already has titan + bake patterns from MTP.

Local baseline on `gemma-4-31B-it-IQ4_XS` target + `gemma4-31b-it-dflash-Q6_K` drafter currently reports **τ ≈ 1.03 on MT-Bench** (essentially just the bonus token — ~0.2% draft accept, n_accept=2 / n_drafted=945). z-lab's published Gemma τ at conc=1 / BF16 / block=16: **MT 4.23, HE 8.00, GSM8K 7.53**. That's the 20× gap Round-12 surfaced — this suite is how we put a number on it on identical inputs.

## Files

| Path | Purpose |
|---|---|
| `scripts/dflash-parity-prompts.json` | 15 prompts × 3 classes (MT-Bench / HumanEval / GSM8K, 5 each). Tracked artifact so both sides run exactly the same set. |
| `scripts/bench-dflash-parity.sh` | Runs the suite against `llama-speculative-simple` at greedy/temp=0 with `--spec-draft-n-max=15`. Emits per-prompt `{tau, n_accept, n_drafted, decode_tps}` as JSON. |

τ = `n_predict / (n_predict - n_accept)` — same convention z-lab uses for `acceptance_lengths` in `dflash_generate`.

## Test plan

- [x] Single-prompt smoke parses correctly: τ=1.0317, n_accept=2, n_drafted=945, JSON well-formed
- [x] JSON schema validates (15 prompts, 3 classes balanced)
- [ ] Full local baseline (in flight)
- [ ] snoop-kube runs same JSON against vLLM/SGLang reference on titan, emits same shape

## Next step (Phase 3)

Coordinate with snoop-kube to run vLLM (or SGLang per z-lab's docker README) with `target=google/gemma-4-31B-it` BF16 + `drafter=z-lab/gemma-4-31B-it-DFlash` against this prompt JSON. Two scenarios after compare:

1. Reference τ ≈ ours → z-lab's published numbers weren't replicable, mark DFlash production-ready as-is.
2. Reference τ >> ours → confirmed graph bug, unpark Path B (local logit-parity via `chore/dflash-parity-dump`, dump infrastructure already committed).