### PR TITLE
fix(tests): test-dflash n_layer assignment after hparams getter refactor

### DIFF
--- a/tests/test-dflash.cpp
+++ b/tests/test-dflash.cpp
@@ -151,7 +151,7 @@ static void test_dflash_swa_defaults() {
     GGML_ASSERT(!hparams.is_swa_any());
 
     // Even with SWA layers marked, is_swa_any returns true only when at least one is set
-    hparams.n_layer = 5;
+    hparams.n_layer_all = 5;
     for (uint32_t il = 0; il < 5; ++il) {
         GGML_ASSERT(hparams.is_swa_impl[il] == 0);
     }
@@ -163,7 +163,7 @@ static void test_dflash_swa_defaults() {
 //
 static void test_dflash_swa_anbeeld_pattern() {
     llama_hparams hparams;
-    hparams.n_layer = 5;
+    hparams.n_layer_all = 5;
     hparams.n_swa = 2048;
     hparams.swa_type = LLAMA_SWA_TYPE_STANDARD;
     hparams.is_swa_impl[0] = 1;


### PR DESCRIPTION
Unbreaks CI: every CUDA/cpu PR build since the #93 upstream sync (2026-06-07) fails compiling `tests/test-dflash.cpp` — the sync vendored upstream's `llama_hparams` getter refactor (`n_layer` is now `n_layer_all - n_layer_nextn`), but the test still assigned `hparams.n_layer`.

`n_layer_nextn` defaults to 0, so `n_layer_all = 5` preserves the tests' intent exactly.

Verified locally: `test-dflash` compiles and all cases pass (sm_86 build, `All DFlash unit tests passed.`).

Found while triaging PR #102's CI — the failures predate that branch; once this lands, re-running #102's checks should clear the CUDA/cpu legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)