### PR TITLE
fix(ggml): TurboQ rotate-block OOB — unbreaks Windows x64 CI

### DIFF
--- a/ggml/src/ggml-turboq.c
+++ b/ggml/src/ggml-turboq.c
@@ -372,10 +372,14 @@ static inline float turboq_block_scale_down(void) {
     return 1.0f / turboq_block_scale_up();
 }
 
+// Note: these operate on one TBQ block (TBQ_BLK_SIZE floats). The loop bound
+// must be TBQ_BLK_SIZE, not QK_K — all callers pass TBQ_BLK_SIZE-sized buffers,
+// and QK_K (256) used to overrun them by 128 floats per call (heap corruption,
+// caught by the Windows CRT heap checker and ASAN in test-quantize-fns/perf).
 static void turboq_rotate_block_forward(float * y, const float * x, uint64_t seed) {
     const float * Q = turboq_get_rotation_row(TURBOQ_KV_DIM, seed);
 
-    for (int64_t i = 0; i < QK_K; i += TURBOQ_KV_DIM) {
+    for (int64_t i = 0; i < TBQ_BLK_SIZE; i += TURBOQ_KV_DIM) {
         matvec_row(y + i, Q, x + i, TURBOQ_KV_DIM);
     }
 }
@@ -383,7 +387,7 @@ static void turboq_rotate_block_forward(float * y, const float * x, uint64_t see
 static void turboq_rotate_block_inverse(float * x, const float * y, uint64_t seed) {
     const float * Q = turboq_get_rotation(TURBOQ_KV_DIM, seed);
 
-    for (int64_t i = 0; i < QK_K; i += TURBOQ_KV_DIM) {
+    for (int64_t i = 0; i < TBQ_BLK_SIZE; i += TURBOQ_KV_DIM) {
         matvec_t(x + i, Q, y + i, TURBOQ_KV_DIM);
     }
 }


### PR DESCRIPTION
## Problem

`windows (x64-cpu-static)` has been red on every PR: `test-quantize-fns` SEGFAULT and `test-quantize-perf` exit `0xc0000374` (STATUS_HEAP_CORRUPTION). Linux legs passed silently.

## Root cause

`turboq_rotate_block_forward`/`_inverse` loop to `QK_K` (256) but all four callers (tbq3_0/tbq4_0 quantize + dequantize) pass `TBQ_BLK_SIZE` (128) float buffers. Every call read **and wrote** 128 floats (512 bytes) past both scratch buffers. The Windows CRT heap checker trips on it; glibc doesn't, which is why Linux CI stayed green.

ASAN confirms pre-fix:

```
ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 4
  #0 matvec_row ggml-turboq.c:260
  #1 turboq_rotate_block_forward ggml-turboq.c:379
  #2 quantize_row_tbq3_0_ref ggml-turboq.c:476
0x... is located 0 bytes after 512-byte region (turboq_get_scratch)
```

## Fix

Loop bound → `TBQ_BLK_SIZE`. Zero behavior change for the valid region — the second iteration only produced out-of-bounds garbage (the rotation tiles in `TURBOQ_KV_DIM`=128 chunks, so the first iteration fully covers the block). May also be implicated in the broken TBQ KV-cache on CPU (#125) — heap corruption next to every dequant call is a plausible mechanism; not yet validated.

## Validation

- `test-quantize-fns` + `test-quantize-perf`: pass under ASAN+UBSAN (RelWithDebInfo, sm-agnostic CPU path) — pre-fix, fns aborts with the trace above.
- RMSE checks in test-quantize-fns unchanged (tbq3_0/tbq4_0/q1_0 all pass).
- This PR's own CI run is the Windows proof.