### PR TITLE
ci: unbreak fork CI — dead self-hosted labels + invalid sycl workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,12 @@
 [flake8]
 max-line-length = 125
 ignore = E203,E211,E221,E225,E231,E241,E251,E261,E266,E501,E701,E704,W503
+# ht: downstream diagnostic CLIs write their reports to stdout by design —
+# upstream's NP100 (no print(), use logging) targets library code.
+per-file-ignores =
+    scripts/gguf-meta.py:NP100
+    scripts/compare-dflash-weights.py:NP100
+    scripts/dflash-logit-parity.py:NP100
 exclude =
     # Do not traverse examples and tools
     examples,

--- a/.github/workflows/build-cmake-pkg.yml
+++ b/.github/workflows/build-cmake-pkg.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   linux:
-    runs-on: [self-hosted, Linux, CPU]
+    # ht: upstream targets ggml-org's runner fleet ([self-hosted, Linux, CPU]);
+    # no runner with those labels exists in this org, so the job queued forever
+    # and CI (cpu) never concluded. Plain cmake build — GitHub-hosted is fine.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-sycl.yml
+++ b/.github/workflows/build-sycl.yml
@@ -24,6 +24,17 @@ env:
 
 jobs:
 
+  # ht: placeholder so the workflow file stays schema-valid while every real
+  # SYCL job below is commented out. An empty `jobs:` map is an INVALID
+  # workflow, and GitHub surfaces invalid workflow files as a zero-job
+  # "failure" run on every push — even with the auto-triggers stripped (#74).
+  # Never executes (`if: false`); delete it when upstream re-enables SYCL CI.
+  sycl-disabled-upstream:
+    runs-on: ubuntu-latest
+    if: ${{ false }}
+    steps:
+      - run: 'true'
+
 # TODO: this build is disabled to save Github Actions resources (https://github.com/ggml-org/llama.cpp/pull/23705)
 #       in order to enable it again, we have to provision dedicated runners  to run it
 #  ubuntu-24-sycl:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -22,7 +22,9 @@ concurrency:
 
 jobs:
   flake8-lint:
-    runs-on: [self-hosted, fast]
+    # ht: upstream's [self-hosted, fast] runner doesn't exist in this org —
+    # every run since 2026-05-24 queued forever. GitHub-hosted is fine for lint.
+    runs-on: ubuntu-latest
     name: Lint
     steps:
       - name: Check out source repository

--- a/scripts/dflash-logit-parity.py
+++ b/scripts/dflash-logit-parity.py
@@ -104,7 +104,7 @@ def cmd_reference(args):
     diffusion forward to produce per-position draft logits."""
     torch = _need("torch")
     _need("transformers")
-    np = _need("numpy")
+    _need("numpy")
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
     # Data-driven constants from the actual drafter config (never hardcoded).


### PR DESCRIPTION
Three fork-side CI defects, all inherited from upstream's runner topology. Together with #104 (TurboQ OOB) this makes the repo's CI actually able to go green.

## 1. `build-cmake-pkg` queued forever → CI (cpu) never concludes

`runs-on: [self-hosted, Linux, CPU]` targets ggml-org's runner fleet. The only runner registered in this org is `ht-org-k8s-*` (`self-hosted, Linux, X64, k8s`) — no `CPU` label, so the job has queued forever on **every** run since the 2026-06-07 CI refactor sync, leaving the `CI (cpu)` workflow permanently unconcluded (even on master, where every other leg passes). It's a plain cmake build+consume test → `ubuntu-latest` (repo is public, GitHub-hosted is free).

## 2. flake8 Lint dead since 2026-05-24

`runs-on: [self-hosted, fast]` — same story, no such runner. Every run queues until GitHub expires it. → `ubuntu-latest`.

## 3. build-sycl: zero-job "failure" run on every push

#74 stripped the auto-triggers, but the file is schema-**invalid** (all jobs commented out = empty `jobs:` map), and GitHub surfaces invalid workflow files as a zero-job failure run on every push **regardless of triggers** — confirmed: pushes of refs containing #74's strip still produced failure runs. Fix: a never-running (`if: false`) placeholder job so the file parses. Delete when upstream re-enables SYCL CI.

## Validation

- All three files pass YAML parse.
- This PR's own checks + the next push to ht demonstrate: no sycl failure run, flake8 actually runs, CI (cpu) concludes.