### PR TITLE
fix(server): return 400 (not 500) for truncated tool-call args in input (#19)

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2173,7 +2173,18 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
+                            // std::invalid_argument maps to HTTP 400 in the server's
+                            // ex_wrapper (server.cpp), whereas std::runtime_error becomes a
+                            // generic 500. A parse failure here almost always means a prior
+                            // tool call in the message history was truncated mid-output
+                            // because the conversation hit the context-size limit, so surface
+                            // it as an actionable client error instead of a server fault.
+                            // See heiervang-technologies/ht-llama.cpp#19.
+                            throw std::invalid_argument(
+                                "Invalid tool call arguments in input messages: " + std::string(e.what()) +
+                                ". This usually means a previous tool call was truncated because the "
+                                "conversation reached the context-size limit; reduce the conversation "
+                                "history or increase --ctx-size, then retry.");
                         }
                     }
                 }

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -319,6 +319,50 @@ def test_completion_without_tool_call_fast(template_name: str, n_predict: int, t
     do_test_completion_without_tool_call(server, n_predict, tools, tool_choice, stream=stream == CompletionMode.STREAMED)
 
 
+def test_input_with_truncated_tool_call_arguments_returns_400():
+    # Regression for #19: when a tool_call in the input message history carries an
+    # `arguments` string that is invalid JSON — which happens when a prior response
+    # was truncated because the conversation hit the context-size limit — the server
+    # must answer with a 400 client error and an actionable hint, not a generic 500.
+    # A 500 traps agentic clients (Codex CLI etc.) in endless retry loops because the
+    # history only grows. The parse failure is raised in func_args_not_string()
+    # (common/chat.cpp), gated on the template advertising object-arguments support;
+    # the Hermes-2-Pro tool_use template does.
+    #
+    # The truncated call must be followed by a tool result + a fresh user turn: a
+    # *trailing* assistant tool_call is stripped by the continue-final-message path
+    # before func_args_not_string runs, so it would not exercise the bug.
+    global server
+    server.jinja = True
+    server.chat_template_file = '../../../models/templates/NousResearch-Hermes-2-Pro-Llama-3-8B-tool_use.jinja'
+    server.start()
+    res = server.make_request("POST", "/v1/chat/completions", data={
+        "max_tokens": 8,
+        "tools": [TEST_TOOL],
+        "messages": [
+            {"role": "user", "content": "Call the test tool."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_truncated",
+                        "type": "function",
+                        "function": {
+                            "name": "test",
+                            "arguments": '{"success": tr',  # truncated mid-value: invalid JSON
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_truncated", "content": "ok"},
+            {"role": "user", "content": "continue"},
+        ],
+    })
+    assert res.status_code == 400, f"Expected 400, got {res.status_code}: {res.body}"
+    assert "context-size limit" in res.body["error"]["message"], res.body
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("stream", [CompletionMode.NORMAL, CompletionMode.STREAMED])
 @pytest.mark.parametrize("template_name,n_predict,tools,tool_choice", [


### PR DESCRIPTION
## Summary

Closes #19 (Part 2). Truncated tool-call arguments in the input message history now produce an actionable **HTTP 400** instead of a misleading **500**.

### The bug
When a `/v1/responses` or `/v1/chat/completions` conversation hits the `--ctx-size` limit, the model can emit a tool call whose `arguments` JSON is cut off mid-string. The client echoes that truncated tool call back in the next request's history. `func_args_not_string()` (`common/chat.cpp`) then fails to `json::parse` it and threw `std::runtime_error`, which the server's `ex_wrapper` (`server.cpp`) maps to a **generic 500 with no cause**. Agentic clients (Codex CLI, etc.) cannot diagnose this and retry forever — the history only grows, so it never recovers.

### The fix
Throw `std::invalid_argument` instead. `ex_wrapper` already maps that to **400** (`ERROR_TYPE_INVALID_REQUEST`), and the message now names the likely root cause and the remedy:

```
Invalid tool call arguments in input messages: <json parse error w/ column>.
This usually means a previous tool call was truncated because the conversation
reached the context-size limit; reduce the conversation history or increase
--ctx-size, then retry.
```

This matches the existing idiom in the file — OAI message-shape validation already throws `std::invalid_argument` for malformed input.

### Part 1 was already done
The other half of #19 (`status:"incomplete"` + `incomplete_details:{reason:"max_output_tokens"}` when `stop == STOP_TYPE_LIMIT`) is already implemented in `server-task.cpp` (`to_json_oaicompat_resp` / `_stream`). This PR completes the remaining Part 2.

## Test
Adds `test_input_with_truncated_tool_call_arguments_returns_400` to `test_tool_call.py`. Notable: the truncated call must sit **mid-history** (followed by a tool result + user turn) — a *trailing* assistant tool_call is stripped by the continue-final-message path before the parse runs, so it wouldn't exercise the bug. Uses the Hermes-2-Pro `tool_use` template, which advertises object-arguments support (verified via `llama-debug-template-parser`).

```
unit/test_tool_call.py::test_input_with_truncated_tool_call_arguments_returns_400 PASSED
7 passed, 196 deselected   # full non-slow tool-call suite, no regressions
```

Backend rebuilt + smoke-tested live (`llama-server` + Hermes-2-Pro template): malformed mid-history args → `HTTP 400`; valid history unaffected.