### PR TITLE
fix(decode): reserve >= dflash_block_size outputs for DFlash draft contexts (#108)

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -208,6 +208,15 @@ llama_context::llama_context(
 
     cparams.n_outputs_max = params.n_outputs_max == 0 || llama_model_has_encoder(&model) ? cparams.n_batch : params.n_outputs_max;
 
+    // DFlash decodes an entire diffusion block per step with every token flagged
+    // for output (block_size tokens), so the output buffer must hold at least the
+    // block size. The server sizes draft contexts to n_parallel (server-context.cpp),
+    // which is < dflash_block_size and trips GGML_ASSERT(n_outputs_max <= cparams.n_outputs_max)
+    // in output_reserve() on the first draft(). See heiervang-technologies/ht-llama.cpp#108.
+    if (model.arch == LLM_ARCH_DFLASH) {
+        cparams.n_outputs_max = std::max(cparams.n_outputs_max, model.hparams.dflash_block_size);
+    }
+
     cparams.op_offload = params.op_offload;
     cparams.kv_unified = params.kv_unified;
 


### PR DESCRIPTION
**Draft** — the fix is complete and the diagnosis is high-confidence, but it must be smoke-tested against the cluster DFlash model before un-drafting (no local repro — `gemma-4-31b-dflash-Q6_K` is 62 G, doesn't fit here).

## Root cause (full trace in #108)
The DFlash draft decodes the entire diffusion block in one `llama_decode` with every token `logits=true` (`common/speculative.cpp:1325-1331`), so `n_outputs_all == dflash_block_size` (default 16). But the server sizes the draft context's output buffer to `n_parallel` (`tools/server/server-context.cpp:933`, unconditional), so `output_reserve(16)` trips `GGML_ASSERT(n_outputs_max <= cparams.n_outputs_max)` (`llama-context.cpp:2407`) on the **first** `draft()` → the "loads clean, child dies on first decode" crash. MTP survives the same line because it outputs `n_parallel` per step; DFlash needs `>= block_size`.

## Fix
Clamp `cparams.n_outputs_max` up to `dflash_block_size` in the `llama_context` ctor for DFlash-arch models:
```cpp
if (model.arch == LLM_ARCH_DFLASH) {
    cparams.n_outputs_max = std::max(cparams.n_outputs_max, model.hparams.dflash_block_size);
}
```
In-library guard → defends every caller, not just the server path.

## Validation
- ✅ Compiles clean (`llama-server` links; pre-existing clang-tidy warnings only, none on the change).
- ✅ Non-DFlash server load + `/completion` works (the ctor change is a no-op for non-DFlash — guarded on `model.arch`).
- ⏳ **Pending:** cluster smoke against `gemma-4-31b-dflash-Q6_K` — load + first `draft()` should now succeed instead of `GGML_ASSERT`. Un-draft once green.

Filed per `/home/me/IDLE.md` (draft-PR blocked-on-verification items rather than hold).