### PR TITLE
ci: strip phantom auto-triggers from self-hosted-only workflows (#84)

### DIFF
--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -2,25 +2,11 @@ name: CI (openvino)
 
 on:
   workflow_dispatch: # allows manual triggering
-  push:
-    branches:
-      - master
-    paths: [
-      '.github/workflows/build-openvino.yml',
-      '**/CMakeLists.txt',
-      '**/.cmake',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp',
-    ]
-
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-openvino.yml',
-      'ggml/src/ggml-openvino/**'
-    ]
+  # Auto-triggers (push/pull_request) stripped on the ht fork: this workflow needs
+  # [self-hosted, Linux, Intel, OpenVINO] runners that don't exist in this fork's
+  # runner pool, so triggered runs sit QUEUED forever and pollute PR status
+  # (UNSTABLE). workflow_dispatch remains for manual runs. See #84; same fix as
+  # build-sycl (#74) / build-cann (#80). Re-add when runners are provisioned.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -2,46 +2,12 @@ name: CI (self-hosted)
 
 on:
   workflow_dispatch: # allows manual triggering
-  push:
-    branches:
-      - master
-    paths: [
-      '.github/workflows/build.yml',
-      '**/CMakeLists.txt',
-      '**/.cmake',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp',
-      '**/*.cu',
-      '**/*.cuh',
-      '**/*.swift',
-      '**/*.m',
-      '**/*.metal',
-      '**/*.comp',
-      '**/*.glsl',
-      '**/*.wgsl'
-    ]
-
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-self-hosted.yml',
-      '**/CMakeLists.txt',
-      '**/.cmake',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp',
-      '**/*.cu',
-      '**/*.cuh',
-      '**/*.swift',
-      '**/*.m',
-      '**/*.metal',
-      '**/*.comp',
-      '**/*.glsl',
-      '**/*.wgsl'
-    ]
+  # Auto-triggers (push/pull_request) stripped on the ht fork: this workflow needs
+  # [self-hosted, Linux, NVIDIA] runners that don't exist in this fork's runner
+  # pool, so every triggered run sits QUEUED forever, polluting PR status (UNSTABLE)
+  # and the Actions dashboard. workflow_dispatch remains for manual runs. See #84;
+  # same fix as build-sycl (#74) / build-cann (#80). Re-add the upstream trigger
+  # block when self-hosted runners are provisioned.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -11,22 +11,11 @@ on:
         description: 'Run slow tests'
         required: true
         type: boolean
-  push:
-    branches:
-      - master
-    paths: [
-      '.github/workflows/server-self-hosted.yml',
-      '**/CMakeLists.txt',
-      '**/Makefile',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp',
-      '**/*.cu',
-      '**/*.swift',
-      '**/*.m',
-      'tools/server/**.*'
-    ]
+  # Auto-trigger (push) stripped on the ht fork: this workflow needs
+  # [self-hosted, llama-server, macOS, ARM64] runners that don't exist in this
+  # fork's runner pool, so triggered runs sit QUEUED forever and pollute PR
+  # status (UNSTABLE). workflow_dispatch remains for manual runs. See #84; same
+  # fix as build-sycl (#74) / build-cann (#80). Re-add when runners are provisioned.
 
 env:
   LLAMA_ARG_LOG_COLORS: 1

--- a/.github/workflows/ui-self-hosted.yml
+++ b/.github/workflows/ui-self-hosted.yml
@@ -11,23 +11,11 @@ on:
         description: 'Commit SHA1 to build'
         required: false
         type: string
-  push:
-    branches:
-      - master
-    paths: [
-      '.github/workflows/ui-self-hosted.yml',
-      '.github/workflows/ui-build-self-hosted.yml',
-      'tools/ui/**.*',
-      'tools/server/tests/**.*'
-    ]
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/ui-self-hosted.yml',
-      '.github/workflows/ui-build-self-hosted.yml',
-      'tools/ui/**.*',
-      'tools/server/tests/**.*'
-    ]
+  # Auto-triggers (push/pull_request) stripped on the ht fork: this workflow needs
+  # [self-hosted, PLAYWRIGHT] runners that don't exist in this fork's runner pool,
+  # so triggered runs sit QUEUED forever and pollute PR status (UNSTABLE).
+  # workflow_dispatch remains for manual runs. See #84; same fix as build-sycl
+  # (#74) / build-cann (#80). Re-add when runners are provisioned.
 
 env:
   LLAMA_ARG_LOG_COLORS: 1

--- a/.github/workflows/update-ops-docs.yml
+++ b/.github/workflows/update-ops-docs.yml
@@ -1,18 +1,12 @@
 name: Update Operations Documentation
 
 on:
-    push:
-        paths:
-            - '.github/workflows/update-ops-docs.yml'
-            - 'docs/ops.md'
-            - 'docs/ops/**'
-            - 'scripts/create_ops_docs.py'
-    pull_request:
-        paths:
-            - '.github/workflows/update-ops-docs.yml'
-            - 'docs/ops.md'
-            - 'docs/ops/**'
-            - 'scripts/create_ops_docs.py'
+    workflow_dispatch: # allows manual triggering
+    # Auto-triggers (push/pull_request) stripped on the ht fork: this workflow
+    # needs [self-hosted, fast, ARM64] runners that don't exist in this fork's
+    # runner pool, so triggered runs sit QUEUED forever and pollute PR status.
+    # See #84; same fix as build-sycl (#74) / build-cann (#80). Re-add when
+    # self-hosted runners are provisioned.
 
 jobs:
     update-ops-docs:


### PR DESCRIPTION
Resolves the forced-A subset of #84. Five workflows target self-hosted runner labels absent from this fork's pool, so their `push`/`pull_request` triggers queue forever and mark every PR `UNSTABLE`. Stripped the auto-triggers, kept `workflow_dispatch` (added to `update-ops-docs` which lacked it) — same pattern as build-sycl (#74) / build-cann (#80).

**Workflows:** build-self-hosted (NVIDIA), server-self-hosted (macOS-ARM64), ui-self-hosted (Playwright), build-openvino (OpenVINO), update-ops-docs (fast-ARM64).

**Validated:** all five parse as valid YAML, retain `workflow_dispatch` + `jobs`, and have zero remaining auto-triggers. No functional change (these never ran on this fork).

**Follow-up (left in #84):** the lint workflows (flake8 / editorconfig / type-check / requirements-check) could move to `ubuntu-latest` for real coverage — a judgment call deferred.