### PR TITLE
fix(server): idempotent /models/unload for already-stopped models

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1518,7 +1518,13 @@ void server_models_routes::init_routes() {
             return res;
         }
         if (!model->is_running()) {
-            res_err(res, format_error_response("model is not running", ERROR_TYPE_INVALID_REQUEST));
+            // Idempotent unload: the model exists but is already stopped (LRU-evicted,
+            // idle-exited, or crashed), so the caller's target state is already met.
+            // Return success instead of a 400 so clients (e.g. the heierchat webui)
+            // treat unload as a no-op rather than surfacing a spurious "Failed to
+            // unload" when their /v1/models snapshot raced an eviction. 400 is now
+            // reserved for a genuinely unknown model (no meta, handled above).
+            res_ok(res, {{"success", true}, {"already_unloaded", true}});
             return res;
         }
         models.unload(model->name);

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -131,6 +131,36 @@ def test_router_unload_model():
     _wait_for_model_status(model_id, {"unloaded"})
 
 
+def test_router_unload_already_unloaded_is_idempotent():
+    """Unloading a model that is not currently running must be a no-op success,
+    not a 400. The router evicts models on its own (LRU / idle exit), so a client
+    whose /v1/models snapshot is stale would otherwise get a spurious
+    'Failed to unload model'. Genuine unknown models still 400."""
+    global server
+    server.start()
+    model_id = "ggml-org/tinygemma3-GGUF:Q8_0"
+
+    _load_model_and_wait(model_id)
+
+    # First unload actually stops the running instance.
+    first = server.make_request("POST", "/models/unload", data={"model": model_id})
+    assert first.status_code == 200
+    assert first.body.get("success") is True
+    _wait_for_model_status(model_id, {"unloaded"})
+
+    # Second unload of the now-stopped model is an idempotent no-op success.
+    second = server.make_request("POST", "/models/unload", data={"model": model_id})
+    assert second.status_code == 200, f"expected idempotent 200, got {second.status_code}: {second.body}"
+    assert second.body.get("success") is True
+    assert second.body.get("already_unloaded") is True
+
+    # A genuinely unknown model still returns 400 invalid_request.
+    unknown = server.make_request("POST", "/models/unload", data={"model": "non-existent/model"})
+    assert unknown.status_code == 400
+    err = unknown.body.get("error", {}) if isinstance(unknown.body, dict) else {}
+    assert "not found" in (err.get("message") or "").lower()
+
+
 def test_router_models_max_evicts_lru():
     global server
     server.models_max = 2


### PR DESCRIPTION
## Problem

The heierchat webui surfaces **"Failed to unload model: <id>"** when a user clicks unload. Root cause traced on `centurion-llm` (`--models-max 2` + LRU): the router evicts/idle-exits model instances on its own, so a client acting off a stale `/v1/models` snapshot POSTs `/models/unload` for a model the router has **already stopped**. That hits the `!is_running()` branch and returns `400 {"message":"model is not running"}`, which the UI prints verbatim.

Reproduced live: `POST /models/unload {"model":"qwen3.6-35b-a3b"}` → `400` in 0.3ms while `/v1/models` shows it `unloaded`. The happy path (unload a *loaded* model) works fine — this is purely the already-stopped race.

## Fix

Make `/models/unload` **idempotent**: when `get_meta()` finds the model but it is not running, the caller's target state (stopped) is already met — return `200 {success:true, already_unloaded:true}` instead of a 400. `400` is now reserved for a genuinely unknown model (no meta).

`server-models.cpp` (`post_router_models_unload`), one branch changed. `is_running()` = LOADED|LOADING|SLEEPING.

## Test

Adds `test_router_unload_already_unloaded_is_idempotent` covering: real unload → 200; second unload of the now-stopped model → 200 idempotent; unknown model → still 400.

## Coordination

Complements heierchat's webui-side defense-in-depth (treat a 400 "model is not running" as success + refresh `/v1/models` on click) so the UX is fixed on un-upgraded backends too. This server fix is the authoritative one — fixes it for every client. snoop-kube is building + rolling `titan-llm`/`centurion-llm` on the new image; deploy verification to follow in a comment.