### PR TITLE
feat(server): expose KV-cache geometry + quant in /v1/models meta

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3845,6 +3845,11 @@ server_context_meta server_context::get_meta() const {
         /* model_n_embd_inp       */ llama_model_n_embd(impl->model_tgt),
         /* model_n_params         */ llama_model_n_params(impl->model_tgt),
         /* model_size             */ llama_model_size(impl->model_tgt),
+        /* model_n_layer          */ llama_model_n_layer(impl->model_tgt),
+        /* model_n_head           */ llama_model_n_head(impl->model_tgt),
+        /* model_n_head_kv        */ llama_model_n_head_kv(impl->model_tgt),
+        /* cache_type_k           */ ggml_type_name(impl->params_base.cache_type_k),
+        /* cache_type_v           */ ggml_type_name(impl->params_base.cache_type_v),
     };
 }
 
@@ -4976,6 +4981,18 @@ json server_routes::get_model_info() const {
             {"n_embd",      meta->model_n_embd_inp},
             {"n_params",    meta->model_n_params},
             {"size",        meta->model_size},
+            // KV-cache geometry + configured quant so clients can compute exact
+            // KV bytes/token = n_layer*(n_embd_k_gqa+n_embd_v_gqa)*kv_type_size.
+            // n_embd_{k,v}_gqa = n_head_kv * (n_embd/n_head) (head dims equal for
+            // all served models; the public API exposes n_head[_kv] not the gqa
+            // dims directly).
+            {"n_layer",       meta->model_n_layer},
+            {"n_head",        meta->model_n_head},
+            {"n_head_kv",     meta->model_n_head_kv},
+            {"n_embd_k_gqa",  meta->model_n_head > 0 ? (int64_t) meta->model_n_head_kv * meta->model_n_embd_inp / meta->model_n_head : 0},
+            {"n_embd_v_gqa",  meta->model_n_head > 0 ? (int64_t) meta->model_n_head_kv * meta->model_n_embd_inp / meta->model_n_head : 0},
+            {"cache_type_k",  meta->cache_type_k},
+            {"cache_type_v",  meta->cache_type_v},
         }},
     };
 }

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -51,6 +51,13 @@ struct server_context_meta {
     int32_t model_n_embd_inp;
     uint64_t model_n_params;
     uint64_t model_size;
+    // KV-cache geometry + configured cache quant, so clients can compute exact
+    // KV bytes per token = n_layer * (n_embd_k_gqa + n_embd_v_gqa) * kv_type_size.
+    int32_t model_n_layer;
+    int32_t model_n_head;
+    int32_t model_n_head_kv;
+    std::string cache_type_k;
+    std::string cache_type_v;
 };
 
 struct server_context {


### PR DESCRIPTION
## Why

The picker's context-length slider + VRAM-fit (heierchat) was guessing KV-cache size from `n_embd` alone — ~4–8× too high because it ignores **GQA**. The router has the exact geometry; it just wasn't exposed.

## What

Add to each model's `/v1/models` `meta`: `n_layer`, `n_head`, `n_head_kv`, `n_embd_k_gqa`, `n_embd_v_gqa`, and the **live** `cache_type_k`/`cache_type_v`. Clients then compute EXACT KV bytes/token = `n_layer·(n_embd_k_gqa+n_embd_v_gqa)·kv_type_size` and offer an f16/q8/q4 toggle. `n_embd_{k,v}_gqa = n_head_kv·(n_embd/n_head)` (the public API exposes `n_head[_kv]`, not the gqa dims; head dims are equal for all served models). `cache_type` reflects the live KV quant (q8_0 on titan, which halves KV vs f16 — the dominant factor).

## Verified live

`unified-llm:kvmeta-4a1073d3` on titan-llm + centurion-llm. gemma-4-e4b: n_layer=42, n_head_kv=2, n_embd_k_gqa=640, cache_type=q8_0 → 55.8 KiB/tok → 7.49 GB @131k (vs the old n_embd guess's ~132 GB). Loaded models only (cold = no meta; GGUF-header read is the follow-up).