### PR TITLE
fix: clamp n_outputs_max for DFlash models

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -208,6 +208,10 @@ llama_context::llama_context(
 
     cparams.n_outputs_max = params.n_outputs_max == 0 || llama_model_has_encoder(&model) ? cparams.n_batch : params.n_outputs_max;
 
+    if (model.arch == LLM_ARCH_DFLASH) {
+        cparams.n_outputs_max = std::max(cparams.n_outputs_max, model.hparams.dflash_block_size);
+    }
+
     cparams.op_offload = params.op_offload;
     cparams.kv_unified = params.kv_unified;
 


### PR DESCRIPTION
Closes #108. The DFlash block-diffusion speculative decoder crashes on the first decode because cparams.n_outputs_max for the draft context is improperly sized (it takes n_parallel instead of the block size). This PR clamps n_outputs_max up to dflash_block_size in llama-context to fix the reserve.