### PR TITLE
fix(chat): fallback to legacy parser if autoparser generation fails

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2410,7 +2410,8 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         LOG_DBG("%s: generated parser:\n%s\n\nparser generation prompt: %s\n", __func__, arena.dump(arena.root()).c_str(), auto_params.generation_prompt.c_str());
         return auto_params;
     } catch (const std::exception & e) {
-        throw std::invalid_argument(std::string("Unable to generate parser for this template. Automatic parser generation failed: ") + e.what());
+        LOG_WRN("%s: Unable to generate parser for this template. Automatic parser generation failed: %s. Falling back to legacy parser.\n", __func__, e.what());
+        return common_chat_templates_apply_legacy(tmpls, inputs);
     }
 }
 


### PR DESCRIPTION
Replaces #120 (which had merge conflicts). Fixes #117.