### PR TITLE
fix(chat): forward-declare legacy template route (unbreak ht build)

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2281,6 +2281,10 @@ std::optional<common_chat_params> common_chat_try_specialized_template(
     return std::nullopt;
 }
 
+// forward declaration: _apply_jinja's autoparser fallback (below) calls this before its definition
+static common_chat_params common_chat_templates_apply_legacy(const struct common_chat_templates *        tmpls,
+                                                             const struct common_chat_templates_inputs & inputs);
+
 static common_chat_params common_chat_templates_apply_jinja(const struct common_chat_templates *        tmpls,
                                                             const struct common_chat_templates_inputs & inputs) {
     autoparser::generation_params params;


### PR DESCRIPTION
## Problem

`ht` HEAD does not compile. PR #124 (`fix(chat): fallback to legacy parser if autoparser generation fails`) added an autoparser-failure fallback inside `common_chat_templates_apply_jinja()` (`common/chat.cpp:2414`) that calls `common_chat_templates_apply_legacy()`, but that `static` function is defined **later** in the file (line ~2419) with no forward declaration:

```
common/chat.cpp:2414:16: error: 'common_chat_templates_apply_legacy' was not declared in this scope; did you mean 'common_chat_templates_apply_jinja'?
```

The break reached `ht` because the full C++ build (`build-cpu`) is `workflow_dispatch`-only, so push CI (Release / flake8 / Fork Sync) did not catch it.

## Fix

Add a forward declaration of `common_chat_templates_apply_legacy` before `common_chat_templates_apply_jinja`. One line + comment, no behavior change.

## Verification

`cmake --build build --target llama-server` now compiles + links cleanly (it failed on `chat.cpp` before this change).