### PR TITLE
feat(server): support image inputs on the embedding endpoints

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -808,6 +808,73 @@ std::vector<server_tokens> tokenize_input_prompts(const llama_vocab * vocab, mtm
     return result;
 }
 
+// defined below (used by /chat/completions); forward-declared for the embedding path
+static void handle_media(std::vector<raw_buffer> & out_files, json & media_obj, const std::string & media_path);
+
+std::vector<server_tokens> tokenize_embedding_input(const llama_vocab * vocab, mtmd_context * mctx, const json & body, const json & prompt, const std::string & media_path) {
+    // Multimodal embedding inputs. Mirrors the chat-completion content-part handling
+    // so /embedding + /v1/embeddings can embed images, not just text. A media marker
+    // is injected into the text (one per image) so mtmd_tokenize() splices the image
+    // tokens in the right place — without it tokenization fails with "number of
+    // bitmaps does not match number of markers". Supported shapes:
+    //   - OAI content-parts: "input": [{"type":"text","text":"..."},
+    //                                  {"type":"image_url","image_url":{"url":"data:..."}}]
+    //   - legacy field:      {"content":"...", "image_data":[{"data":"<b64>","id":0}]}
+    // Text-only inputs fall through to tokenize_input_prompts() unchanged.
+    const auto require_mtmd = [&]() {
+        if (mctx == nullptr) {
+            throw std::runtime_error("image input is not supported - hint: if this is unexpected, you may need to provide the mmproj");
+        }
+    };
+
+    // (a) OAI content-parts array: a single (possibly multimodal) input.
+    if (prompt.is_array() && !prompt.empty() && prompt.front().is_object() && prompt.front().contains("type")) {
+        std::string text;
+        std::vector<raw_buffer> files;
+        for (const auto & part : prompt) {
+            const std::string type = json_value(part, "type", std::string());
+            if (type == "text") {
+                text += json_value(part, "text", std::string());
+            } else if (type == "image_url") {
+                require_mtmd();
+                json image_url = json_value(part, "image_url", json::object());
+                handle_media(files, image_url, media_path);
+                text += get_media_marker();
+            } else {
+                throw std::invalid_argument("unsupported content[].type for embeddings: " + type);
+            }
+        }
+        if (!files.empty()) {
+            std::vector<server_tokens> result;
+            result.push_back(process_mtmd_prompt(mctx, text, files));
+            return result;
+        }
+        // text-only content-parts: tokenize the concatenated text
+        return tokenize_input_prompts(vocab, mctx, json(text), true, true);
+    }
+
+    // (b) legacy "image_data" sibling field, with "content"/"input" as the text.
+    if (body.contains("image_data") && body.at("image_data").is_array() && !body.at("image_data").empty()) {
+        require_mtmd();
+        if (!prompt.is_string() && !prompt.is_null()) {
+            throw std::invalid_argument("\"content\" must be a string when \"image_data\" is provided");
+        }
+        std::string markers;
+        std::vector<raw_buffer> files;
+        for (const auto & entry : body.at("image_data")) {
+            files.push_back(base64_decode(json_value(entry, "data", std::string())));
+            markers += get_media_marker();
+        }
+        const std::string base = prompt.is_string() ? prompt.get<std::string>() : std::string();
+        std::vector<server_tokens> result;
+        result.push_back(process_mtmd_prompt(mctx, markers + base, files));
+        return result;
+    }
+
+    // text-only: existing behavior.
+    return tokenize_input_prompts(vocab, mctx, prompt, true, true);
+}
+
 //
 // OAI utils
 //

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -286,6 +286,21 @@ std::vector<server_tokens> tokenize_input_prompts(
                                         bool add_special,
                                         bool parse_special);
 
+/**
+ * tokenize the input of the /embedding + /v1/embeddings endpoints, with support for
+ * multimodal (image) inputs in addition to the text shapes handled by
+ * tokenize_input_prompts(). Recognizes OAI content-parts ("input": [{type:image_url}])
+ * and the legacy "image_data": [{data:<base64>}] field, injecting one media marker per
+ * image so the image tokens are spliced in. `body` is the full request object (for the
+ * sibling "image_data" field); `prompt` is the extracted "input"/"content" value.
+ */
+std::vector<server_tokens> tokenize_embedding_input(
+                                        const llama_vocab * vocab,
+                                        mtmd_context * mctx,
+                                        const json & body,
+                                        const json & prompt,
+                                        const std::string & media_path);
+
 //
 // OAI utils
 //

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -5134,7 +5134,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_embeddings_impl(cons
         }
     }
 
-    auto tokenized_prompts = tokenize_input_prompts(ctx_server.vocab, ctx_server.mctx, prompt, true, true);
+    auto tokenized_prompts = tokenize_embedding_input(ctx_server.vocab, ctx_server.mctx, body, prompt, params.media_path);
     for (const auto & tokens : tokenized_prompts) {
         // this check is necessary for models that do not add BOS token to the input
         if (tokens.empty()) {


### PR DESCRIPTION
## Problem

The `/embedding` and `/v1/embeddings` handlers tokenize **text only**. An image sent as either:
- the legacy `image_data: [{ "data": "<b64>", "id": 0 }]` field, or
- OAI `image_url` content-parts (`"input": [{ "type": "image_url", ... }]`)

was silently **dropped** (returning a constant, text-only vector regardless of the image) or rejected with a **500** (`"prompt" elements must be a string...`). mmproj-backed embedding models (e.g. **LCO-Embedding-Omni**) therefore could not produce image embeddings — distinct images returned a near-constant cosine ~0.999.

Root cause: `handle_embeddings_impl()` routed input through `tokenize_input_prompts()`, which only recognizes images via the `{"prompt_string", "multimodal_data":[b64]}` object shape — and even that fails without a media marker (`mtmd_tokenize`: *"number of bitmaps does not match number of markers"*).

## Fix

Add `tokenize_embedding_input()` (`server-common.cpp`), used by `handle_embeddings_impl()`:
- accepts OAI `image_url` content-parts **and** the legacy `image_data` field,
- injects one media marker per image (via `get_media_marker()`) so `mtmd_tokenize` splices the image tokens correctly,
- routes through the existing `process_mtmd_prompt()` path.

Text-only inputs fall through to `tokenize_input_prompts()` unchanged. **No model / mmproj / decode-path change** — the embedding decode loop already encodes mtmd chunks; only the input parser was missing.

## Validation (local, exact model)

Against `LCO-Embedding-Omni-3B-2605-Q4_K_M` + its F16 mmproj, `--embeddings --pooling last`:

| path | distinct images | identical images | image vs text-only |
|---|---|---|---|
| text-only (regression) | 0.553 | 1.000 | — |
| legacy `image_data` (fzi shape) | **0.748** | 1.000 | 0.504 |
| OAI `image_url` | **0.664** | 1.000 | — |

Distinct images now produce distinct vectors and the image measurably shifts the embedding (the vision tower fires). Matches an independent cluster probe (distinct ≈ 0.74). Text embeddings unchanged.

Note: legacy vs OAI shapes differ slightly by design — the legacy path injects the marker first; the OAI path respects the user's content-part order. For `pooling=last` this changes the pooled token, so absolute cosines differ between shapes (this does not affect retrieval, which uses one shape consistently).

## Notes

- Stacked on #125 (the build fix) — base will retarget to `ht` once #125 lands.
- No automated test added: CI has no mmproj-backed embedding model. Validation is the manual harness above.