### PR TITLE
ci(build-cpu): run the compile gate on pushes to ht

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - ht # ht is this fork's default branch; compile-gate merges to it (see #124)
     paths: [
       '.github/workflows/build-cpu.yml',
       '.github/workflows/build-cmake-pkg.yml',


### PR DESCRIPTION
## Why

`build-cpu` (the canonical CPU compile across ubuntu x64/arm64 + windows + cmake-pkg) had `push.branches: [master]` — an upstream leftover never retargeted to this fork's default branch, **`ht`**. So a merge to `ht` never re-ran the compile check on the branch itself.

**This bit us today.** PR #124 landed a non-compiling commit on `ht` (`common/chat.cpp` call-before-definition, fixed in #125). `build-cpu` *ran on #124's PR and failed every job* — but `ht` has no branch protection, so the red PR was merged, and nothing re-flagged the break on `ht` afterward (the red was only on the PR run).

## Change

Add `ht` to `build-cpu.yml`'s `push.branches`, so the default branch gets the same compile-on-push coverage `master` already has. A broken `ht` will now show red on the branch, visible to CI-health sweeps.

`pull_request` already covers PRs to `ht` (it has no base-branch filter), so this only adds the post-merge run.

## Out of scope (maintainer's call)

The stronger prevention — a ruleset *requiring* `build-cpu` to pass before merging to `ht` — is a repo-settings change, and `ht` intentionally runs without branch protection (to avoid phantom self-hosted checks blocking merges). A ruleset requiring **only** `build-cpu` (not the self-hosted phantoms) would prevent red merges without that problem; recommended, but left to the maintainer.