### PR TITLE
feat(server): instruction + chat-template wrappers for embedding inputs

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2856,6 +2856,24 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_EMBEDDING}));
     add_opt(common_arg(
+        {"--embd-prompt-text"}, "TEMPLATE",
+        "wrapper applied to TEXT embedding inputs (instruction/chat template); '{content}' is replaced by the request text. "
+        "empty = off (raw input). \\n \\t escapes are processed. example: \"<|im_start|>user\\n{content}\\nSummarize the above text in one word:<|im_end|>\\n<|im_start|>assistant\\n\"",
+        [](common_params & params, const std::string & value) {
+            params.embd_prompt_text = value;
+            string_process_escapes(params.embd_prompt_text); // so preset-passed \n become real newlines
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_EMBEDDING}).set_env("LLAMA_ARG_EMBD_PROMPT_TEXT"));
+    add_opt(common_arg(
+        {"--embd-prompt-image"}, "TEMPLATE",
+        "wrapper applied to IMAGE embedding inputs (instruction/chat template); '{media}' is replaced by the server's media marker (one per image), request content is ignored. "
+        "empty = off. requires --mmproj. \\n \\t escapes are processed. example: \"<|im_start|>user\\n{media}\\nSummarize the above image in one word:<|im_end|>\\n<|im_start|>assistant\\n\"",
+        [](common_params & params, const std::string & value) {
+            params.embd_prompt_image = value;
+            string_process_escapes(params.embd_prompt_image); // so preset-passed \n become real newlines
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_EMBEDDING}).set_env("LLAMA_ARG_EMBD_PROMPT_IMAGE"));
+    add_opt(common_arg(
         {"--cls-separator"}, "STRING",
         "separator of classification sequences (default \\t) for example \"<#seq#>\"",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -592,6 +592,10 @@ struct common_params {
     std::string embd_out   = "";    // empty = default, "array" = [[],[]...], "json" = openai style, "json+" = same "json" + cosine similarity matrix
     std::string embd_sep   = "\n";  // separator of embeddings
     std::string cls_sep    = "\t";  // separator of classification sequences
+    // per-modality embedding prompt wrappers (instruction + chat template). empty = off (raw input).
+    // {content} is replaced by the request text; {media} by the server's media marker (one per image).
+    std::string embd_prompt_text  = ""; // applied to text-only embedding inputs
+    std::string embd_prompt_image = ""; // applied to image embedding inputs (request content is ignored)
 
     // server params
     int32_t port                = 8080;          // server listens on this network port

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -811,7 +811,7 @@ std::vector<server_tokens> tokenize_input_prompts(const llama_vocab * vocab, mtm
 // defined below (used by /chat/completions); forward-declared for the embedding path
 static void handle_media(std::vector<raw_buffer> & out_files, json & media_obj, const std::string & media_path);
 
-std::vector<server_tokens> tokenize_embedding_input(const llama_vocab * vocab, mtmd_context * mctx, const json & body, const json & prompt, const std::string & media_path) {
+std::vector<server_tokens> tokenize_embedding_input(const llama_vocab * vocab, mtmd_context * mctx, const json & body, const json & prompt, const std::string & media_path, const std::string & embd_prompt_text, const std::string & embd_prompt_image) {
     // Multimodal embedding inputs. Mirrors the chat-completion content-part handling
     // so /embedding + /v1/embeddings can embed images, not just text. A media marker
     // is injected into the text (one per image) so mtmd_tokenize() splices the image
@@ -820,16 +820,27 @@ std::vector<server_tokens> tokenize_embedding_input(const llama_vocab * vocab, m
     //   - OAI content-parts: "input": [{"type":"text","text":"..."},
     //                                  {"type":"image_url","image_url":{"url":"data:..."}}]
     //   - legacy field:      {"content":"...", "image_data":[{"data":"<b64>","id":0}]}
-    // Text-only inputs fall through to tokenize_input_prompts() unchanged.
+    //
+    // When embd_prompt_{text,image} are set, they wrap the input (instruction + chat
+    // template): {content} -> request text, {media} -> the marker(s). The image wrapper
+    // ignores the request text entirely (so e.g. an empty or stray content can't leak in).
+    // Empty wrappers => raw input (legacy behavior).
     const auto require_mtmd = [&]() {
         if (mctx == nullptr) {
             throw std::runtime_error("image input is not supported - hint: if this is unexpected, you may need to provide the mmproj");
         }
     };
+    const auto subst = [](std::string s, const std::string & from, const std::string & to) {
+        for (size_t p = s.find(from); p != std::string::npos; p = s.find(from, p + to.size())) {
+            s.replace(p, from.size(), to);
+        }
+        return s;
+    };
 
     // (a) OAI content-parts array: a single (possibly multimodal) input.
     if (prompt.is_array() && !prompt.empty() && prompt.front().is_object() && prompt.front().contains("type")) {
         std::string text;
+        std::string markers;
         std::vector<raw_buffer> files;
         for (const auto & part : prompt) {
             const std::string type = json_value(part, "type", std::string());
@@ -839,18 +850,21 @@ std::vector<server_tokens> tokenize_embedding_input(const llama_vocab * vocab, m
                 require_mtmd();
                 json image_url = json_value(part, "image_url", json::object());
                 handle_media(files, image_url, media_path);
-                text += get_media_marker();
+                text    += get_media_marker();
+                markers += get_media_marker();
             } else {
                 throw std::invalid_argument("unsupported content[].type for embeddings: " + type);
             }
         }
+        std::vector<server_tokens> result;
         if (!files.empty()) {
-            std::vector<server_tokens> result;
-            result.push_back(process_mtmd_prompt(mctx, text, files));
+            const std::string str = embd_prompt_image.empty() ? text : subst(embd_prompt_image, "{media}", markers);
+            result.push_back(process_mtmd_prompt(mctx, str, files));
             return result;
         }
-        // text-only content-parts: tokenize the concatenated text
-        return tokenize_input_prompts(vocab, mctx, json(text), true, true);
+        // text-only content-parts
+        const std::string str = embd_prompt_text.empty() ? text : subst(embd_prompt_text, "{content}", text);
+        return tokenize_input_prompts(vocab, mctx, json(str), true, true);
     }
 
     // (b) legacy "image_data" sibling field, with "content"/"input" as the text.
@@ -866,12 +880,30 @@ std::vector<server_tokens> tokenize_embedding_input(const llama_vocab * vocab, m
             markers += get_media_marker();
         }
         const std::string base = prompt.is_string() ? prompt.get<std::string>() : std::string();
+        const std::string str  = embd_prompt_image.empty() ? (markers + base) : subst(embd_prompt_image, "{media}", markers);
         std::vector<server_tokens> result;
-        result.push_back(process_mtmd_prompt(mctx, markers + base, files));
+        result.push_back(process_mtmd_prompt(mctx, str, files));
         return result;
     }
 
-    // text-only: existing behavior.
+    // (c) text-only with a text wrapper: wrap a single string, or each element of a
+    //     string batch ("input": ["a", "b"]).
+    if (!embd_prompt_text.empty()) {
+        if (prompt.is_string()) {
+            return tokenize_input_prompts(vocab, mctx, json(subst(embd_prompt_text, "{content}", prompt.get<std::string>())), true, true);
+        }
+        if (prompt.is_array() && !prompt.empty() && json_is_array_of_mixed_numbers_strings(prompt) == false) {
+            bool all_strings = true;
+            for (const auto & e : prompt) { if (!e.is_string()) { all_strings = false; break; } }
+            if (all_strings) {
+                json wrapped = json::array();
+                for (const auto & e : prompt) { wrapped.push_back(subst(embd_prompt_text, "{content}", e.get<std::string>())); }
+                return tokenize_input_prompts(vocab, mctx, wrapped, true, true);
+            }
+        }
+    }
+
+    // default: raw input (also handles token-list arrays / object shapes unchanged).
     return tokenize_input_prompts(vocab, mctx, prompt, true, true);
 }
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -293,13 +293,21 @@ std::vector<server_tokens> tokenize_input_prompts(
  * and the legacy "image_data": [{data:<base64>}] field, injecting one media marker per
  * image so the image tokens are spliced in. `body` is the full request object (for the
  * sibling "image_data" field); `prompt` is the extracted "input"/"content" value.
+ *
+ * When `embd_prompt_text` / `embd_prompt_image` are non-empty, they are per-modality
+ * wrappers (instruction + chat template) applied to the input: '{content}' is replaced
+ * by the request text, '{media}' by the model's media marker (one per image). This lets
+ * instruction-tuned embedding models (e.g. LCO-Embedding-Omni) get the trained prompt
+ * format server-side without any client change. Empty = raw input (legacy behavior).
  */
 std::vector<server_tokens> tokenize_embedding_input(
                                         const llama_vocab * vocab,
                                         mtmd_context * mctx,
                                         const json & body,
                                         const json & prompt,
-                                        const std::string & media_path);
+                                        const std::string & media_path,
+                                        const std::string & embd_prompt_text,
+                                        const std::string & embd_prompt_image);
 
 //
 // OAI utils

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -5134,7 +5134,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_embeddings_impl(cons
         }
     }
 
-    auto tokenized_prompts = tokenize_embedding_input(ctx_server.vocab, ctx_server.mctx, body, prompt, params.media_path);
+    auto tokenized_prompts = tokenize_embedding_input(ctx_server.vocab, ctx_server.mctx, body, prompt, params.media_path, params.embd_prompt_text, params.embd_prompt_image);
     for (const auto & tokens : tokenized_prompts) {
         // this check is necessary for models that do not add BOS token to the input
         if (tokens.empty()) {


### PR DESCRIPTION
## Problem

Instruction-tuned embedding models (e.g. **LCO-Embedding-Omni** / Qwen2.5-Omni) require their inputs wrapped in a **task instruction + the chat template**, then last-token pooled. The `/embedding` path tokenizes **raw** content, so the trained embedding position is never hit and retrieval — especially cross-modal text↔image — collapses to near-random. (This is the follow-up to #126, which stopped images being *dropped* but left retrieval quality poor.)

Measured on `LCO-Embedding-Omni-3B-2605` (last-token, normalize): **raw input → cross-modal margin +0.002 (≈random)**; the correct recipe → **+0.30, correct ranking**.

## Change

Two opt-in, per-modality wrapper flags (empty = off = current raw behavior):
- `--embd-prompt-text "…{content}…"` — text inputs; `{content}` → request text.
- `--embd-prompt-image "…{media}…"` — image inputs; `{media}` → the **server's** media marker (one per image), request content ignored.

`{media}` substitution solves the random-per-restart marker problem, so **clients send raw content unchanged** (zero client change). `\n`/`\t` escapes are processed (`string_process_escapes`) so values survive INI/preset quoting. Modality is inferred from the request (`image_data` field / OAI `image_url` parts). The recipe is symmetric (query == document) so no role field is needed.

## Validation

Built + run with the flags via a **preset-style literal-`\n` CLI** (proves escape resolution). Sending **raw** requests, the server applies the recipe:
- text same−cross margin: +0.21 (raw) → **+0.30**
- cross-modal q="red circle": red 0.65 vs blue 0.35, **+0.30 RIGHT** (raw: +0.002)
- output L2-normalized ✓

Deployed via the omniswap preset's per-model block (LCO only; qwen3-embed / embeddinggemma stay raw). Follows #126 / #125 / #127.