### PR TITLE
feat(server meta): expose SWA geometry in /v1/models meta

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -572,6 +572,8 @@ extern "C" {
     LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head_kv  (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_swa      (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_swa_layers(const struct llama_model * model);
+    LLAMA_API const char * llama_model_swa_type_name(const struct llama_model * model);
 
     // DFlash draft model metadata
     LLAMA_API int32_t llama_model_dflash_block_size  (const struct llama_model * model);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2339,6 +2339,26 @@ int32_t llama_model_n_swa(const llama_model * model) {
     return model->hparams.n_swa;
 }
 
+int32_t llama_model_n_swa_layers(const llama_model * model) {
+    const auto & hparams = model->hparams;
+    int32_t n = 0;
+    for (uint32_t il = 0; il < hparams.n_layer(); ++il) {
+        if (hparams.is_swa(il)) {
+            n++;
+        }
+    }
+    return n;
+}
+
+const char * llama_model_swa_type_name(const llama_model * model) {
+    switch (model->hparams.swa_type) {
+        case LLAMA_SWA_TYPE_NONE:      return "none";
+        case LLAMA_SWA_TYPE_STANDARD:  return "standard";
+        case LLAMA_SWA_TYPE_CHUNKED:   return "chunked";
+        case LLAMA_SWA_TYPE_SYMMETRIC: return "symmetric";
+    }
+    return "none";
+}
 
 uint32_t llama_model_n_cls_out(const struct llama_model * model) {
     return model->hparams.n_cls_out;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3850,6 +3850,9 @@ server_context_meta server_context::get_meta() const {
         /* model_n_head_kv        */ llama_model_n_head_kv(impl->model_tgt),
         /* cache_type_k           */ ggml_type_name(impl->params_base.cache_type_k),
         /* cache_type_v           */ ggml_type_name(impl->params_base.cache_type_v),
+        /* model_n_swa            */ llama_model_n_swa(impl->model_tgt),
+        /* model_n_swa_layers     */ llama_model_n_swa_layers(impl->model_tgt),
+        /* model_swa_type         */ llama_model_swa_type_name(impl->model_tgt),
     };
 }
 
@@ -4993,6 +4996,12 @@ json server_routes::get_model_info() const {
             {"n_embd_v_gqa",  meta->model_n_head > 0 ? (int64_t) meta->model_n_head_kv * meta->model_n_embd_inp / meta->model_n_head : 0},
             {"cache_type_k",  meta->cache_type_k},
             {"cache_type_v",  meta->cache_type_v},
+            // SWA geometry for exact KV prediction on hybrid models
+            // (gemma-4 etc.): n_full_layers = n_layer - n_swa_layers;
+            // SWA layers cap KV at min(ctx, n_swa) instead of ctx.
+            {"n_swa",         meta->model_n_swa},
+            {"n_swa_layers",  meta->model_n_swa_layers},
+            {"swa_type",      meta->model_swa_type},
         }},
     };
 }

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -58,6 +58,11 @@ struct server_context_meta {
     int32_t model_n_head_kv;
     std::string cache_type_k;
     std::string cache_type_v;
+    // SWA geometry so clients can compute exact KV for hybrid models
+    // (gemma-4 etc.) where SWA layers cap KV at min(ctx, n_swa).
+    int32_t     model_n_swa;
+    int32_t     model_n_swa_layers;
+    std::string model_swa_type;
 };
 
 struct server_context {


### PR DESCRIPTION
Closes #123.

## What

Adds 3 new fields to the `/v1/models` meta object so clients (heierchat VRAM panel) can compute **exact** KV bytes/token for SWA-hybrid models (gemma-4 12B/31B, gemma-4-12b-256k@gem) instead of the current safe-upper-bound estimate.

### New meta fields (per loaded model)

| Field | Source | Example (gemma-4 12B) |
|---|---|---|
| `n_swa` | `llama_model_n_swa(model)` | `1024` |
| `n_swa_layers` | **new** `llama_model_n_swa_layers(model)` | `40` |
| `swa_type` | **new** `llama_model_swa_type_name(model)` | `"standard"` |

### New public API

```c
LLAMA_API int32_t    llama_model_n_swa_layers(const struct llama_model * model);
LLAMA_API const char * llama_model_swa_type_name(const struct llama_model * model);
```

### Exact KV formula the FE will compute

```
kv_per_tok(ctx) = (k_gqa + v_gqa) * kv_type_bytes * (
                    n_full_layers
                  + n_swa_layers * min(ctx, n_swa) / ctx )
```

where `n_full_layers = n_layer - n_swa_layers`.

### Verification

- CPU-only build (`-DGGML_CUDA=OFF`): compiles clean, zero warnings
- Purely additive — no behavior change until consumers read the fields

### Files changed (4, +36 lines)

- `include/llama.h` — 2 new API declarations
- `src/llama-model.cpp` — implementations (layer-count loop + enum→string)
- `tools/server/server-context.h` — 3 new fields in `server_context_meta`
- `tools/server/server-context.cpp` — populate + emit in `/v1/models` JSON