### PR TITLE
chore(ci): finish migrating lint workflows to ubuntu-latest

### DIFF
--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     pre-tokenizer-hashes:
-        runs-on: [self-hosted, fast]
+        runs-on: ubuntu-latest
 
         steps:
         - name: Checkout repository

--- a/.github/workflows/python-check-requirements.yml
+++ b/.github/workflows/python-check-requirements.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   python-check-requirements:
-    runs-on: [self-hosted, CPU, fast]
+    runs-on: ubuntu-latest
     name: check-requirements
     steps:
       - name: Check out source repository


### PR DESCRIPTION
Converts the final two phantom workflows to ubuntu-latest, addressing #84.