### PR TITLE
fix(server): implement in-router memory fit and VRAM-based eviction (#66)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1183,19 +1183,9 @@ struct common_init_result::impl {
 
 common_init_result::common_init_result(common_params & params, bool model_only) :
     pimpl(new impl{}) {
-    auto mparams = common_model_params_to_llama(params);
-    auto cparams = common_context_params_to_llama(params);
-
-    if (params.fit_params) {
-        LOG_INF("%s: fitting params to device memory ...\n", __func__);
-        LOG_INF("%s: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)\n", __func__);
-        common_fit_params(params.model.path.c_str(), &mparams, &cparams,
-            params.tensor_split,
-            params.tensor_buft_overrides.data(),
-            params.fit_params_target.data(),
-            params.fit_params_min_ctx,
-            params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
-    }
+    auto fitted = common_fit_params_from_common_params(params);
+    auto mparams = fitted.mparams;
+    auto cparams = fitted.cparams;
 
     llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);
     if (model == NULL) {

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -1,4 +1,5 @@
 #include "fit.h"
+#include "common.h"
 
 #include "log.h"
 
@@ -997,4 +998,85 @@ void common_fit_print(
     printf("%zu ", dmd.back().mb.context/1024/1024);
     printf("%zu ", dmd.back().mb.compute/1024/1024);
     printf("\n");
+}
+
+common_fitted_params common_fit_params_from_common_params(common_params & params) {
+    common_fitted_params res;
+    res.mparams = common_model_params_to_llama(params);
+    res.cparams = common_context_params_to_llama(params);
+
+    std::vector<ggml_backend_dev_t> model_devs;
+
+    if (params.fit_params) {
+        res.fit_status = common_fit_params(params.model.path.c_str(), &res.mparams, &res.cparams,
+            params.tensor_split,
+            params.tensor_buft_overrides.data(),
+            params.fit_params_target.data(),
+            params.fit_params_min_ctx,
+            params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR,
+            &res.per_device_bytes);
+
+        // Retrieve model devices by loading model headers with no_alloc = true
+        llama_model_params mparams_copy = res.mparams;
+        mparams_copy.no_alloc = true;
+        mparams_copy.use_mmap = false;
+        mparams_copy.use_mlock = false;
+        llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams_copy);
+        if (model) {
+            for (int i = 0; i < llama_model_n_devices(model); i++) {
+                model_devs.push_back(llama_model_get_device(model, i));
+            }
+            llama_model_free(model);
+        }
+    } else {
+        uint32_t hp_ngl = 0;
+        uint32_t hp_n_ctx_train = 0;
+        uint32_t hp_n_expert = 0;
+        try {
+            auto dmd = common_get_device_memory_data(params.model.path.c_str(), &res.mparams, &res.cparams,
+                model_devs, hp_ngl, hp_n_ctx_train, hp_n_expert,
+                params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
+            if (!model_devs.empty()) {
+                res.per_device_bytes.clear();
+                res.per_device_bytes.reserve(model_devs.size());
+                for (size_t id = 0; id < model_devs.size(); id++) {
+                    res.per_device_bytes.push_back((int64_t)(dmd[id].model + dmd[id].context + dmd[id].compute));
+                }
+            }
+        } catch (const std::exception & e) {
+            LOG_WRN("%s: failed to measure device memory: %s\n", __func__, e.what());
+            res.fit_status = COMMON_PARAMS_FIT_STATUS_ERROR;
+        }
+    }
+
+    // Now, align res.per_device_bytes to the system's global GPUs
+    std::vector<ggml_backend_dev_t> system_gpus;
+    for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+            system_gpus.push_back(dev);
+        }
+    }
+
+    if (!system_gpus.empty() && !res.per_device_bytes.empty() && res.per_device_bytes.size() <= model_devs.size()) {
+        std::vector<int64_t> aligned_bytes(system_gpus.size(), 0);
+        for (size_t i = 0; i < res.per_device_bytes.size(); i++) {
+            ggml_backend_dev_t dev = model_devs[i];
+            int gpu_idx = -1;
+            for (size_t idx = 0; idx < system_gpus.size(); idx++) {
+                if (system_gpus[idx] == dev) {
+                    gpu_idx = idx;
+                    break;
+                }
+            }
+            if (gpu_idx != -1) {
+                aligned_bytes[gpu_idx] = res.per_device_bytes[i];
+            }
+        }
+        res.per_device_bytes = std::move(aligned_bytes);
+    } else if (!system_gpus.empty()) {
+        res.per_device_bytes.assign(system_gpus.size(), 0);
+    }
+
+    return res;
 }

--- a/common/fit.h
+++ b/common/fit.h
@@ -5,6 +5,8 @@
 
 #include <vector>
 
+struct common_params;
+
 enum common_params_fit_status {
     COMMON_PARAMS_FIT_STATUS_SUCCESS = 0, // found allocations that are projected to fit
     COMMON_PARAMS_FIT_STATUS_FAILURE = 1, // could not find allocations that are projected to fit
@@ -63,3 +65,13 @@ common_device_memory_data_vec common_get_device_memory_data(
                            uint32_t & hp_n_ctx_train,
                            uint32_t & hp_n_expert,
                      ggml_log_level   log_level);
+
+struct common_fitted_params {
+    struct llama_model_params mparams;
+    struct llama_context_params cparams;
+    common_params_fit_status fit_status = COMMON_PARAMS_FIT_STATUS_SUCCESS;
+    std::vector<int64_t> per_device_bytes;
+};
+
+// Converts common_params to model/context params, and fits/measures them
+common_fitted_params common_fit_params_from_common_params(common_params & params);

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -256,6 +256,7 @@ void server_models::add_model(server_model_meta && meta) {
             alias = string_strip(alias);
             if (!alias.empty()) {
                 meta.aliases.insert(alias);
+                alias_to_name[alias] = meta.name;
             }
         }
     }
@@ -542,6 +543,15 @@ void server_models::load_models() {
             }
         }
 
+        // clean up alias_to_name map
+        for (auto it = alias_to_name.begin(); it != alias_to_name.end(); ) {
+            if (mapping.find(it->second) == mapping.end()) {
+                it = alias_to_name.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
         // update presets for non-running models still in source
         for (auto & [name, inst] : mapping) {
             if (inst.meta.is_running()) continue;
@@ -702,6 +712,13 @@ std::optional<server_model_meta> server_models::get_meta(const std::string & nam
     auto it = mapping.find(name);
     if (it != mapping.end()) {
         return it->second.meta;
+    }
+    auto ait = alias_to_name.find(name);
+    if (ait != alias_to_name.end()) {
+        auto mit = mapping.find(ait->second);
+        if (mit != mapping.end()) {
+            return mit->second.meta;
+        }
     }
     for (const auto & [key, inst] : mapping) {
         if (inst.meta.aliases.count(name)) {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1,5 +1,6 @@
 #include "server-common.h"
 #include "server-models.h"
+#include "fit.h"
 
 #include "build-info.h"
 #include "preset.h"
@@ -205,8 +206,22 @@ void server_model_meta::update_caps() {
         } else {
             multimodal = mtmd_get_cap_from_file(params.mmproj.path.c_str());
         }
+
+        // Compute memory footprint across GPU/accelerator devices
+        common_params fit_params;
+        preset.apply_to_params(fit_params);
+        fit_params.offline = true;
+        common_params_handle_models(fit_params, LLAMA_EXAMPLE_SERVER);
+
+        auto fitted = common_fit_params_from_common_params(fit_params);
+        if (fitted.fit_status == COMMON_PARAMS_FIT_STATUS_SUCCESS) {
+            per_device_bytes = fitted.per_device_bytes;
+        } else {
+            LOG_WRN("failed to compute device memory fit plan for model '%s': status = %d\n",
+                    name.c_str(), (int)fitted.fit_status);
+        }
     } catch (const std::exception & e) {
-        LOG_WRN("failed to initialize common_params for multimodal capability detection: %s\n", e.what());
+        LOG_WRN("failed to initialize common_params for multimodal capability/memory footprint detection: %s\n", e.what());
         multimodal = { false, false };
     }
 }
@@ -429,20 +444,21 @@ void server_models::load_models() {
         // FIRST LOAD: add all models, then unlock for autoloading
         for (const auto & [name, preset] : final_presets) {
             server_model_meta meta{
-                /* source        */ get_source(name),
-                /* preset        */ preset,
-                /* name          */ name,
-                /* aliases       */ {},
-                /* tags          */ {},
-                /* port          */ 0,
-                /* status        */ SERVER_MODEL_STATUS_UNLOADED,
-                /* last_used     */ 0,
-                /* args          */ std::vector<std::string>(),
-                /* loaded_info   */ {},
-                /* exit_code     */ 0,
-                /* stop_timeout  */ DEFAULT_STOP_TIMEOUT,
-                /* multimodal    */ mtmd_caps{false, false},
-                // /* need_download */ false,
+                /* source           */ get_source(name),
+                /* preset           */ preset,
+                /* name             */ name,
+                /* aliases          */ {},
+                /* tags             */ {},
+                /* port             */ 0,
+                /* status           */ SERVER_MODEL_STATUS_UNLOADED,
+                /* last_used        */ 0,
+                /* args             */ std::vector<std::string>(),
+                /* loaded_info      */ {},
+                /* exit_code        */ 0,
+                /* stop_timeout     */ DEFAULT_STOP_TIMEOUT,
+                /* multimodal       */ mtmd_caps{false, false},
+                /* need_download    */ false,
+                /* per_device_bytes */ {}
             };
             add_model(std::move(meta));
         }
@@ -604,20 +620,21 @@ void server_models::load_models() {
         for (const auto & [name, preset] : final_presets) {
             if (mapping.find(name) == mapping.end()) {
                 server_model_meta meta{
-                    /* source        */ get_source(name),
-                    /* preset        */ preset,
-                    /* name          */ name,
-                    /* aliases       */ {},
-                    /* tags          */ {},
-                    /* port          */ 0,
-                    /* status        */ SERVER_MODEL_STATUS_UNLOADED,
-                    /* last_used     */ 0,
-                    /* args          */ std::vector<std::string>(),
-                    /* loaded_info   */ {},
-                    /* exit_code     */ 0,
-                    /* stop_timeout  */ DEFAULT_STOP_TIMEOUT,
-                    /* multimodal    */ mtmd_caps{false, false},
-                    // /* need_download */ false,
+                    /* source           */ get_source(name),
+                    /* preset           */ preset,
+                    /* name             */ name,
+                    /* aliases          */ {},
+                    /* tags             */ {},
+                    /* port             */ 0,
+                    /* status           */ SERVER_MODEL_STATUS_UNLOADED,
+                    /* last_used        */ 0,
+                    /* args             */ std::vector<std::string>(),
+                    /* loaded_info      */ {},
+                    /* exit_code        */ 0,
+                    /* stop_timeout     */ DEFAULT_STOP_TIMEOUT,
+                    /* multimodal       */ mtmd_caps{false, false},
+                    /* need_download    */ false,
+                    /* per_device_bytes */ {}
                 };
                 add_model(std::move(meta));
                 newly_added.push_back(name);
@@ -821,38 +838,100 @@ std::vector<common_lora_adapter_info> server_models::get_discovered_adapters() {
     return discovered_adapters;
 }
 
-void server_models::unload_lru() {
-    if (base_params.models_max <= 0) {
-        return; // no limit
-    }
-    // remove one of the servers if we passed the models_max (least recently used - LRU)
-    std::string lru_model_name = "";
-    int64_t lru_last_used = ggml_time_ms();
-    size_t count_active = 0;
-    {
-        std::unique_lock<std::mutex> lk(mutex);
-        for (const auto & m : mapping) {
-            if (m.second.meta.is_running()) {
-                count_active++;
-                if (m.second.meta.last_used < lru_last_used) {
-                    lru_model_name = m.first;
-                    lru_last_used = m.second.meta.last_used;
+void server_models::unload_lru(const std::string & candidate_name) {
+    while (true) {
+        size_t count_active = 0;
+        bool mem_fits = true;
+        std::vector<int64_t> candidate_bytes;
+
+        {
+            std::unique_lock<std::mutex> lk(mutex);
+            // 1. Check count limit
+            for (const auto & m : mapping) {
+                if (m.second.meta.is_running()) {
+                    count_active++;
+                }
+            }
+
+            // 2. Fetch candidate VRAM bytes
+            auto map_it = mapping.find(candidate_name);
+            if (map_it != mapping.end()) {
+                candidate_bytes = map_it->second.meta.per_device_bytes;
+            }
+        }
+
+        bool count_ok = (base_params.models_max <= 0) || (count_active < (size_t)base_params.models_max);
+
+        // 3. Query physical free memory for GPUs
+        std::vector<int64_t> projected_free;
+        for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+            ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+            if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+                size_t free = 0;
+                size_t total = 0;
+                ggml_backend_dev_memory(dev, &free, &total);
+                projected_free.push_back(free);
+            }
+        }
+
+        // 4. Check if candidate memory footprint fits and collect constrained devices
+        std::vector<size_t> constrained_devices;
+        if (!candidate_bytes.empty()) {
+            for (size_t id = 0; id < candidate_bytes.size() && id < projected_free.size(); id++) {
+                if (candidate_bytes[id] > projected_free[id]) {
+                    mem_fits = false;
+                    constrained_devices.push_back(id);
                 }
             }
         }
-    }
-    if (!lru_model_name.empty() && count_active >= (size_t)base_params.models_max) {
-        SRV_INF("models_max limit reached, removing LRU name=%s\n", lru_model_name.c_str());
+
+        // If both limits are satisfied, we can stop!
+        if (count_ok && mem_fits) {
+            break;
+        }
+
+        // 5. Find the LRU active model to evict
+        std::string lru_model_name = "";
+        int64_t lru_last_used = ggml_time_ms();
+
+        {
+            std::unique_lock<std::mutex> lk(mutex);
+            for (const auto & m : mapping) {
+                if (m.second.meta.is_running()) {
+                    bool helps_memory = false;
+                    if (!mem_fits) {
+                        for (size_t id : constrained_devices) {
+                            if (id < m.second.meta.per_device_bytes.size() && m.second.meta.per_device_bytes[id] > 0) {
+                                helps_memory = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    // We can evict if we need to reduce count, OR if it helps constrained memory
+                    if (!count_ok || helps_memory) {
+                        if (m.second.meta.last_used < lru_last_used) {
+                            lru_model_name = m.first;
+                            lru_last_used = m.second.meta.last_used;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (lru_model_name.empty()) {
+            break; // No more models left to unload that would help
+        }
+
+        SRV_INF("evicting LRU model '%s' (last_used=%" PRId64 ") to make room for '%s' (count_ok=%d, mem_fits=%d)\n",
+                lru_model_name.c_str(), lru_last_used, candidate_name.c_str(), count_ok, mem_fits);
+
         unload(lru_model_name);
+
         // wait for unload to complete
         {
             std::unique_lock<std::mutex> lk(mutex);
             cv.wait(lk, [this, &lru_model_name]() {
-                // operator[] on std::map silently default-inserts on miss; with a
-                // default-init server_model_meta (status = UNLOADED) the predicate
-                // would spuriously return true AND pollute mapping. Use find().
-                // Missing model → treat as done (was unloaded by another thread or
-                // removed by a concurrent reload).
                 auto it = mapping.find(lru_model_name);
                 if (it == mapping.end()) return true;
                 return it->second.meta.status == SERVER_MODEL_STATUS_UNLOADED;
@@ -865,7 +944,7 @@ void server_models::load(const std::string & name) {
     if (!has_model(name)) {
         throw std::runtime_error("model name=" + name + " is not found");
     }
-    unload_lru();
+    unload_lru(name);
 
     std::unique_lock<std::mutex> lk(mutex);
     // edge case: block until any in-progress reload has finished so we always load

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -119,6 +119,8 @@ private:
     std::mutex mutex;
     std::condition_variable cv;
     std::map<std::string, instance_t> mapping;
+    std::map<std::string, std::string> alias_to_name;
+
 
     // for stopping models
     std::condition_variable cv_stop;

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -76,6 +76,7 @@ struct server_model_meta {
     int stop_timeout = 0; // seconds to wait before force-killing the model instance during shutdown
     mtmd_caps multimodal; // multimodal capabilities
     bool need_download = false; // whether the model needs to be downloaded before loading
+    std::vector<int64_t> per_device_bytes; // per-device VRAM footprint plan (in bytes)
 
     bool is_ready() const {
         return status == SERVER_MODEL_STATUS_LOADED;
@@ -144,8 +145,8 @@ private:
 
     void update_meta(const std::string & name, const server_model_meta & meta);
 
-    // unload least recently used models if the limit is reached
-    void unload_lru();
+    // unload least recently used models if the limit is reached or memory is tight
+    void unload_lru(const std::string & candidate_name);
 
     // not thread-safe, caller must hold mutex
     void add_model(server_model_meta && meta);


### PR DESCRIPTION
Implements per-device memory limits for same-device pinned models during router admission and eviction. Extracts preset-to-llama-params conversion and parameter fitting logic into a shared helper that can be safely run without process-level exit side effects during admission dry-runs. Aligns device allocations with system-wide GPU indices for robust comparison.