### PR TITLE
feat(mtmd): add support for MoonViT / LocateAnything-3B projector

### DIFF
--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -363,6 +363,7 @@ enum projector_type {
     PROJECTOR_TYPE_GRANITE_SPEECH,
     PROJECTOR_TYPE_MIMOVL,
     PROJECTOR_TYPE_GRANITE4_VISION,
+    PROJECTOR_TYPE_LOCATEANYTHING,
     PROJECTOR_TYPE_UNKNOWN,
 };
 
@@ -417,6 +418,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_GRANITE_SPEECH,    "granite_speech"},
     { PROJECTOR_TYPE_MIMOVL,            "mimovl"},
     { PROJECTOR_TYPE_GRANITE4_VISION,   "granite4_vision"},
+    { PROJECTOR_TYPE_LOCATEANYTHING,    "locateanything"},
 };
 
 static projector_type clip_projector_type_from_string(const std::string & str) {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -294,18 +294,35 @@ ggml_tensor * clip_graph::resize_position_embeddings(uint32_t interpolation_mode
     if (ggml_n_dims(pos_embd) == 3) {
         orig_w = pos_embd->ne[1];
         orig_h = pos_embd->ne[2];
-    } else {
-        orig_w = (int)std::sqrt(pos_embd->ne[1]);
-        orig_h = orig_w;
+
+        if (height == orig_h && width == orig_w) {
+            return ggml_cont_2d(ctx0, pos_embd, n_embd, width * height);
+        }
+
+        pos_embd = ggml_permute(ctx0, pos_embd, 2, 1, 0, 3);
+        pos_embd = ggml_interpolate(ctx0, pos_embd, height, width, n_embd, 1, mode);
+        pos_embd = ggml_permute(ctx0, pos_embd, 2, 1, 0, 3);
+        pos_embd = ggml_cont_2d(ctx0, pos_embd, n_embd, width * height);
+        return pos_embd;
     }
+
+    // 2D case
+    orig_w = (int)std::sqrt(pos_embd->ne[1]);
+    orig_h = orig_w;
 
     if (height == orig_h && width == orig_w) {
         return pos_embd;
     }
 
-    if (ggml_n_dims(pos_embd) != 3) {
-        pos_embd = ggml_reshape_3d(ctx0, pos_embd, n_embd, orig_w, orig_h);  // -> (n_embd, orig_w, orig_h)
+    // We must handle cases where ne[1] is not a perfect square (e.g. contains CLS token).
+    // If it's not a square, ggml_reshape_3d will assert if we don't slice it.
+    const int expected_elements = orig_w * orig_h;
+    if (pos_embd->ne[1] > expected_elements) {
+        const int extra_tokens = pos_embd->ne[1] - expected_elements;
+        pos_embd = ggml_view_2d(ctx0, pos_embd, n_embd, expected_elements, pos_embd->nb[1], extra_tokens * pos_embd->nb[1]);
     }
+
+    pos_embd = ggml_reshape_3d(ctx0, pos_embd, n_embd, orig_w, orig_h);  // -> (n_embd, orig_w, orig_h)
     pos_embd = ggml_permute(ctx0, pos_embd, 2, 0, 1, 3);                         // -> (orig_w, orig_h, n_embd)
     pos_embd = ggml_interpolate(ctx0, pos_embd, width, height, n_embd, 1, mode); // -> (width, height, n_embd)
     pos_embd = ggml_permute(ctx0, pos_embd, 1, 2, 0, 3);                         // -> (n_embd, width, height)

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -287,16 +287,26 @@ ggml_tensor * clip_graph::resize_position_embeddings(uint32_t interpolation_mode
     const int height       = img.ny() / patch_size;
     const int width        = img.nx() / patch_size;
     const uint32_t mode    = interpolation_mode;
-    const int n_per_side   = (int)std::sqrt(pos_embd->ne[1]);
 
     GGML_ASSERT(pos_embd);
 
-    if (height == n_per_side && width == n_per_side) {
+    int orig_w, orig_h;
+    if (ggml_n_dims(pos_embd) == 3) {
+        orig_w = pos_embd->ne[1];
+        orig_h = pos_embd->ne[2];
+    } else {
+        orig_w = (int)std::sqrt(pos_embd->ne[1]);
+        orig_h = orig_w;
+    }
+
+    if (height == orig_h && width == orig_w) {
         return pos_embd;
     }
 
-    pos_embd = ggml_reshape_3d(ctx0, pos_embd, n_embd, n_per_side, n_per_side);  // -> (n_embd, n_per_side, n_per_side)
-    pos_embd = ggml_permute(ctx0, pos_embd, 2, 0, 1, 3);                         // -> (n_per_side, n_per_side, n_embd)
+    if (ggml_n_dims(pos_embd) != 3) {
+        pos_embd = ggml_reshape_3d(ctx0, pos_embd, n_embd, orig_w, orig_h);  // -> (n_embd, orig_w, orig_h)
+    }
+    pos_embd = ggml_permute(ctx0, pos_embd, 2, 0, 1, 3);                         // -> (orig_w, orig_h, n_embd)
     pos_embd = ggml_interpolate(ctx0, pos_embd, width, height, n_embd, 1, mode); // -> (width, height, n_embd)
     pos_embd = ggml_permute(ctx0, pos_embd, 1, 2, 0, 3);                         // -> (n_embd, width, height)
     pos_embd = ggml_cont_2d(ctx0, pos_embd, n_embd, width * height);             // -> (n_embd, width * height)

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -949,6 +949,7 @@ static std::unique_ptr<clip_graph> clip_get_graph_builder(clip_ctx * ctx, const 
                 builder = std::make_unique<clip_graph_whisper_enc>(ctx, img);
             } break;
         case PROJECTOR_TYPE_KIMIVL:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
             {
                 builder = std::make_unique<clip_graph_kimivl>(ctx, img);
             } break;
@@ -1379,9 +1380,11 @@ struct clip_model_loader {
                         hparams.set_warmup_n_tokens(46*46); // avoid OOM on warmup
                     } break;
                 case PROJECTOR_TYPE_KIMIVL:
+                case PROJECTOR_TYPE_LOCATEANYTHING:
                     {
                         hparams.image_resize_algo = RESIZE_ALGO_BILINEAR;
                         hparams.rope_theta = 10000.0f;
+                        hparams.n_merge = 1; // Default to 1 if not present
                         get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
                         // TODO: check kimivl preprocessor for exact values
                         hparams.set_limit_image_tokens(8, 1024);
@@ -2279,6 +2282,15 @@ struct clip_model_loader {
                 {
                     model.mm_input_norm_w = get_tensor(TN_MM_INP_NORM);
                     model.mm_input_norm_b = get_tensor(TN_MM_INP_NORM_B);
+                    model.mm_1_w = get_tensor(string_format(TN_LLAVA_PROJ, 1, "weight"));
+                    model.mm_1_b = get_tensor(string_format(TN_LLAVA_PROJ, 1, "bias"));
+                    model.mm_2_w = get_tensor(string_format(TN_LLAVA_PROJ, 2, "weight"));
+                    model.mm_2_b = get_tensor(string_format(TN_LLAVA_PROJ, 2, "bias"));
+                } break;
+            case PROJECTOR_TYPE_LOCATEANYTHING:
+                {
+                    model.mm_input_norm_w = get_tensor("mm.input_norm.weight");
+                    model.mm_input_norm_b = get_tensor("mm.input_norm.bias");
                     model.mm_1_w = get_tensor(string_format(TN_LLAVA_PROJ, 1, "weight"));
                     model.mm_1_b = get_tensor(string_format(TN_LLAVA_PROJ, 1, "bias"));
                     model.mm_2_w = get_tensor(string_format(TN_LLAVA_PROJ, 2, "weight"));
@@ -3281,6 +3293,7 @@ int clip_n_output_tokens(const clip_ctx * ctx, const clip_image_f32 * img) {
             } break;
         case PROJECTOR_TYPE_LFM2:
         case PROJECTOR_TYPE_KIMIVL:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
         case PROJECTOR_TYPE_KIMIK25:
             {
                 // dynamic size
@@ -3940,6 +3953,7 @@ bool clip_image_batch_encode(clip_ctx * ctx, int n_threads, const clip_image_f32
             } break;
         case PROJECTOR_TYPE_PIXTRAL:
         case PROJECTOR_TYPE_KIMIVL:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
         case PROJECTOR_TYPE_KIMIK25:
         case PROJECTOR_TYPE_LIGHTONOCR:
             {
@@ -4490,6 +4504,7 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
         case PROJECTOR_TYPE_PADDLEOCR:
         case PROJECTOR_TYPE_KIMIK25:
         case PROJECTOR_TYPE_YASA2:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
             return ctx->model.mm_2_w->ne[1];
         case PROJECTOR_TYPE_HUNYUANVL:
             return ctx->model.mm_model_proj->ne[1];

--- a/tools/mtmd/models/kimivl.cpp
+++ b/tools/mtmd/models/kimivl.cpp
@@ -30,20 +30,26 @@ ggml_cgraph * clip_graph_kimivl::build() {
 
     {
         // patch_merger
-        const int scale_factor = model.hparams.n_merge;
-        cur = build_patch_merge_permute(cur, scale_factor);
+        const int scale_factor = model.hparams.n_merge > 0 ? model.hparams.n_merge : 1;
+        if (scale_factor > 1) {
+            cur = build_patch_merge_permute(cur, scale_factor);
+        }
 
         // projection norm
         int proj_inp_dim = cur->ne[0];
-        cur = ggml_view_2d(ctx0, cur,
-            n_embd, cur->ne[1] * scale_factor * scale_factor,
-            ggml_row_size(cur->type, n_embd), 0);
+        if (scale_factor > 1) {
+            cur = ggml_view_2d(ctx0, cur,
+                n_embd, cur->ne[1] * scale_factor * scale_factor,
+                ggml_row_size(cur->type, n_embd), 0);
+        }
         cur = ggml_norm(ctx0, cur, 1e-5); // default nn.LayerNorm
         cur = ggml_mul(ctx0, cur, model.mm_input_norm_w);
         cur = ggml_add(ctx0, cur, model.mm_input_norm_b);
-        cur = ggml_view_2d(ctx0, cur,
-            proj_inp_dim, cur->ne[1] / scale_factor / scale_factor,
-            ggml_row_size(cur->type, proj_inp_dim), 0);
+        if (scale_factor > 1) {
+            cur = ggml_view_2d(ctx0, cur,
+                proj_inp_dim, cur->ne[1] / scale_factor / scale_factor,
+                ggml_row_size(cur->type, proj_inp_dim), 0);
+        }
         cb(cur, "proj_inp_normed", -1);
 
         // projection mlp
@@ -51,7 +57,7 @@ ggml_cgraph * clip_graph_kimivl::build() {
             model.mm_1_w, model.mm_1_b,
             nullptr, nullptr,
             model.mm_2_w, model.mm_2_b,
-            FFN_GELU,
+            proj_type == PROJECTOR_TYPE_LOCATEANYTHING ? FFN_GELU_ERF : FFN_GELU,
             -1);
         cb(cur, "proj_out", -1);
     }

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -453,6 +453,7 @@ struct mtmd_context {
             case PROJECTOR_TYPE_QWEN25VL:
             case PROJECTOR_TYPE_QWEN3VL:
             case PROJECTOR_TYPE_MIMOVL:
+            case PROJECTOR_TYPE_LOCATEANYTHING:
                 {
                     // <|vision_start|> ... (image embeddings) ... <|vision_end|>
                     img_beg = "<|vision_start|>";


### PR DESCRIPTION
Adds support for the MoonViT / LocateAnything-3B vision projector in the mtmd stack. Reuses the Kimi-VL vision graph builder (which also uses MoonViT) and adapts it to use GELU_ERF activation and a custom tensor naming scheme prefixed with 'proj.' as present in the LocateAnything GGUF weights.