### PR TITLE
ci(release): remove ht from push triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - master
-      - ht
     paths: [
       '.github/workflows/release.yml',
       '**/CMakeLists.txt',


### PR DESCRIPTION
Removes '- ht' from release.yml branches list to stop release runs from triggering on push to ht branch, eliminating UNSTABLE PR rollup noise.