### PR TITLE
fix(mtmd): do not reshape before projection norm for LocateAnything

### DIFF
--- a/tools/mtmd/models/kimivl.cpp
+++ b/tools/mtmd/models/kimivl.cpp
@@ -37,7 +37,8 @@ ggml_cgraph * clip_graph_kimivl::build() {
 
         // projection norm
         int proj_inp_dim = cur->ne[0];
-        if (scale_factor > 1) {
+        bool is_locateanything = (proj_type == PROJECTOR_TYPE_LOCATEANYTHING);
+        if (scale_factor > 1 && !is_locateanything) {
             cur = ggml_view_2d(ctx0, cur,
                 n_embd, cur->ne[1] * scale_factor * scale_factor,
                 ggml_row_size(cur->type, n_embd), 0);
@@ -45,7 +46,7 @@ ggml_cgraph * clip_graph_kimivl::build() {
         cur = ggml_norm(ctx0, cur, 1e-5); // default nn.LayerNorm
         cur = ggml_mul(ctx0, cur, model.mm_input_norm_w);
         cur = ggml_add(ctx0, cur, model.mm_input_norm_b);
-        if (scale_factor > 1) {
+        if (scale_factor > 1 && !is_locateanything) {
             cur = ggml_view_2d(ctx0, cur,
                 proj_inp_dim, cur->ne[1] / scale_factor / scale_factor,
                 ggml_row_size(cur->type, proj_inp_dim), 0);


### PR DESCRIPTION
## What
Skip the KimiVL pixel-unshuffle `ggml_view_2d` reshape around the projection LayerNorm when the projector is `PROJECTOR_TYPE_LOCATEANYTHING`. Five lines in `tools/mtmd/models/kimivl.cpp` (guards both the pre-norm and post-norm views with `&& !is_locateanything`).

## Why
PR #137 landed the LocateAnything-3B (MoonViT + Eagle MLP + Qwen2.5-3B) runtime, but LocateAnything reuses the KimiVL graph **without** KimiVL's pixel-unshuffle. With the reshape applied, the projection-norm `ggml_mul`/`ggml_add` broadcast mismatches and aborts:

```
ggml/src/ggml.c: GGML_ASSERT(ggml_can_repeat(b, a)) failed
```

This is the one fix from the `feat/mtmd-locateanything-projector` branch that did not make it into #137 (the `resize_position_embeddings` and `reshape_2d` fixes are already on `ht`).

## Validation
Built `llama-mtmd-cli` from `origin/ht` + this commit and ran the **existing community GGUF** `yuuko-eth/LocateAnything-3B-GGUF` (Q4_K_M LLM + BF16 mmproj, `clip.projector_type = 'locateanything'`) on the NYT "MEN WALK ON MOON" test image:

| Prompt | Box (0–1000, x1 y1 x2 y2) | Location |
|---|---|---|
| `Please locate the text referred as MEN WALK ON MOON.` | `67,253 → 896,364` | full-width headline ✓ |
| `Please locate the text referred as 10 CENTS.` | `840,221 → 898,242` | top-right price ✓ |
| `Please locate the text referred as Eagle Has Landed.` | `81,597 → 272,632` | lower-left column ✓ |

- **Before this commit (`origin/ht`):** aborts on `ggml_can_repeat` during image encode — no output.
- **After:** loads and grounds correctly. Runs under both `-fa off` and `-fa on` (our CUDA flash-attn handles the vision `head_dim=72`; no assert).

Note: the community GGUF is already correctly tagged `locateanything`, so no converter is required to serve it — this C++ guard is the only blocker.