### PR TITLE
fix(server): reconcile alias_to_name on reload (#150)

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -633,6 +633,25 @@ void server_models::load_models() {
                 if (!conflict) inst.meta.aliases.insert(alias);
             }
 
+            // Keep the global alias_to_name map in sync with this model's re-parsed aliases (#150).
+            // Without this, an alias removed from (or moved off) a still-existing model leaves a
+            // stale alias_to_name entry, and get_meta() — which consults alias_to_name before the
+            // authoritative meta.aliases scan — mis-resolves the alias to the old model.
+            // Scoped to the (non-running) model being re-parsed: erase only its own entries, then
+            // register its current aliases. Running models' entries (which #135 deliberately keeps
+            // when a loaded instance's meta.aliases are shadowed/lost) are left untouched. Correct
+            // for add/remove/move regardless of the iteration order over models.
+            for (auto ait = alias_to_name.begin(); ait != alias_to_name.end(); ) {
+                if (ait->second == name) {
+                    ait = alias_to_name.erase(ait);
+                } else {
+                    ++ait;
+                }
+            }
+            for (const auto & alias : inst.meta.aliases) {
+                alias_to_name[alias] = name;
+            }
+
             // re-parse tags
             inst.meta.tags.clear();
             std::string tags_str;


### PR DESCRIPTION
Fixes #150.

## Problem
`load_models()` reload rebuilds each non-running model's `meta.aliases` but never reconciled the global `alias_to_name` map (the pre-loop cleanup at `server-models.cpp:595` only drops entries whose *target model* is gone). Since `get_meta()` consults `alias_to_name` **before** the authoritative `meta.aliases` scan, an alias **removed from** or **moved off** a still-existing model kept resolving to the old model — while `has_model()` (which skips the map) disagreed. Editing a preset INI to rename/move an alias + `POST /models/reload` reproduces it.

## Fix
After the re-parse loop finalizes a model's `meta.aliases`, reconcile the map: erase that model's own entries, then register its current aliases. Correct for add/remove/move regardless of the order models are iterated.

**Scoping (why not clear-and-rebuild the whole map):** #135 (`ecf2de428`) added `alias_to_name` specifically so aliases still resolve when a *loaded* instance's `meta.aliases` are shadowed/lost, and reload only re-parses **non-running** models. So the reconcile is scoped to the model being re-parsed — a running instance's entries are left untouched, preserving #135's behavior.

## Verification
- CPU `cmake --build --target llama-server` (`GGML_CUDA=OFF`) — `server-models.cpp` compiles clean, links. CI covers the matrix.
- Independent of #148 (that PR touches `unload_lru`/`load`/`update_status`; this touches `load_models` reload) — different regions, no conflict, mergeable in either order.

## Testing note
The bug lives in `get_meta()`'s `alias_to_name` fast-path, which is hard to isolate through the black-box HTTP API (the correct `meta.aliases` scan masks it, and no endpoint echoes `get_meta`'s resolved name). Did **not** add a non-isolating test rather than a flaky one. A targeted C++ unit test on `server_models` (move an alias between two presets across a reload, assert `get_meta` follows) would be the right home if a test seam is added.

## Known limitation (pre-existing, not introduced here)
Alias-conflict detection during reload (`:624`) uses `meta.aliases`, which can be shadowed for a running model — so a re-parsed model could still claim a running model's alias in that compound edge case. That's the pre-existing weakness #135 works around; this PR doesn't widen or fix it.
