### PR TITLE
fix(server): avoid phantom router entry on proxy last-used bump

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1542,7 +1542,10 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
     }
     if (update_last_used) {
         std::unique_lock<std::mutex> lk(mutex);
-        mapping[name].meta.last_used = ggml_time_ms();
+        auto it = mapping.find(name);
+        if (it != mapping.end()) {
+            it->second.meta.last_used = ggml_time_ms();
+        }
     }
     SRV_INF("proxying request to model %s on port %d\n", name.c_str(), meta->port);
     std::string proxy_path = req.path;


### PR DESCRIPTION
## What

Fixes #154 by changing `server_models::proxy_request` to update `last_used` via `mapping.find(name)` instead of `mapping[name]`. If the model entry disappears during a concurrent reload/remove race, the bump is skipped instead of default-inserting an empty `instance_t`.

## Why

`proxy_request` resolves metadata before proxying, then optionally bumps LRU state under the mutex. The old `operator[]` access could create a phantom UNLOADED model entry if the canonical model was erased between those steps. That phantom could appear in `/models` and later drive an empty-preset child spawn.

## Validation

- `git diff --check`
- `cmake --build build --target llama-server -j 8`
- `./build/bin/llama-server --version`
